### PR TITLE
fix(markdown): CJK-friendly bold/emphasis + feat(crash): auto-reload after renderer crash

### DIFF
--- a/electron/crash-diagnostics.cjs
+++ b/electron/crash-diagnostics.cjs
@@ -6,6 +6,13 @@ const SCHEMA_VERSION = 1
 const DEFAULT_DIRECTORY = 'crash-diagnostics'
 const DEFAULT_MAX_STRING_LENGTH = 192
 
+// Auto-recovery guard rails: reload the window at most once per cooldown and
+// never more than MAX total times, so a renderer crash-loop cannot turn into
+// an infinite reload storm. Document content is persisted near-realtime via
+// the retention store, so a reload loses at most the last debounce window.
+const AUTO_RECOVER_COOLDOWN_MS = 60 * 1000
+const AUTO_RECOVER_MAX = 3
+
 const EVENT_FIELDS = Object.freeze({
   'diagnostics-started': Object.freeze({
     appVersion: 'string',
@@ -27,6 +34,9 @@ const EVENT_FIELDS = Object.freeze({
   }),
   'window-unresponsive': Object.freeze({}),
   'window-responsive': Object.freeze({}),
+  'renderer-auto-recovered': Object.freeze({
+    attempt: 'integer'
+  }),
   'main-uncaught-exception': Object.freeze({
     origin: 'string',
     errorName: 'string',
@@ -118,6 +128,8 @@ class CrashDiagnostics {
     this._listeners = []
     this._windows = new WeakSet()
     this.crashReporterStarted = false
+    this._recoverAt = -Infinity
+    this._recoverCount = 0
   }
 
   _notifyFailure (operation, error) {
@@ -242,6 +254,7 @@ class CrashDiagnostics {
         reason: details.reason,
         exitCode: details.exitCode
       })
+      this._maybeAutoRecover(win, details)
     })
     addListener(this, win, 'unresponsive', () => {
       void this.record('window-unresponsive')
@@ -250,6 +263,29 @@ class CrashDiagnostics {
       void this.record('window-responsive')
     })
     return true
+  }
+
+  _maybeAutoRecover (win, details = {}) {
+    // Only a hard renderer crash is worth reloading for; being killed or
+    // exiting abnormally usually means the app is shutting down or the OS
+    // reclaimed the process (memory pressure), and reloading would fight it.
+    if (details.reason !== 'crashed') return
+    if (this._closed) return
+    if (!win || typeof win.isDestroyed !== 'function' || win.isDestroyed()) return
+    const webContents = win.webContents
+    if (!webContents || typeof webContents.reload !== 'function') return
+    // Cooldown + hard cap keep a crash-loop from becoming a reload storm.
+    const now = this._now()
+    if (now - this._recoverAt < AUTO_RECOVER_COOLDOWN_MS) return
+    if (this._recoverCount >= AUTO_RECOVER_MAX) return
+    this._recoverAt = now
+    this._recoverCount += 1
+    void this.record('renderer-auto-recovered', { attempt: this._recoverCount })
+    try {
+      webContents.reload()
+    } catch (error) {
+      this._notifyFailure('auto-recover-reload', error)
+    }
   }
 
   detach () {

--- a/electron/crash-diagnostics.test.cjs
+++ b/electron/crash-diagnostics.test.cjs
@@ -226,3 +226,78 @@ test('attach does not change Node unhandled rejection behavior by default', asyn
   diagnostics.detach()
   assert.equal(processEmitter.listenerCount('uncaughtExceptionMonitor'), 0)
 })
+
+const makeFakeWindow = (reloads) => {
+  const win = new EventEmitter()
+  win.webContents = new EventEmitter()
+  win.webContents.reload = () => { reloads.count += 1 }
+  win.isDestroyed = () => false
+  return win
+}
+
+const crash = (win) => win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 11 })
+
+test('auto-recovers a crashed renderer with a reload and an audit event', async () => {
+  const { diagnostics } = await fresh()
+  const reloads = { count: 0 }
+  const win = makeFakeWindow(reloads)
+  assert.equal(diagnostics.attachWindow(win), true)
+  crash(win)
+  await diagnostics.flush()
+  assert.equal(reloads.count, 1)
+  const events = await readEvents(diagnostics)
+  assert.equal(events.some((event) => event.event === 'renderer-auto-recovered'), true)
+  assert.equal(events.find((event) => event.event === 'renderer-auto-recovered').attempt, 1)
+})
+
+test('auto-recovery respects the cooldown and the hard cap', async () => {
+  let clock = 0
+  const { diagnostics } = await fresh({ now: () => clock })
+  const reloads = { count: 0 }
+  const win = makeFakeWindow(reloads)
+  diagnostics.attachWindow(win)
+
+  crash(win) // t=0 -> recovered
+  clock += 30 * 1000
+  crash(win) // t=30s, inside 60s cooldown -> no reload
+  assert.equal(reloads.count, 1)
+  clock += 40 * 1000
+  crash(win) // t=70s -> recovered (2)
+  assert.equal(reloads.count, 2)
+  clock += 60 * 1000
+  crash(win) // t=130s -> recovered (3, cap)
+  assert.equal(reloads.count, 3)
+  clock += 60 * 1000
+  crash(win) // t=190s, cap reached -> no reload
+  assert.equal(reloads.count, 3)
+
+  await diagnostics.flush()
+  const attempts = (await readEvents(diagnostics))
+    .filter((event) => event.event === 'renderer-auto-recovered')
+    .map((event) => event.attempt)
+  assert.deepEqual(attempts, [1, 2, 3])
+})
+
+test('auto-recovery ignores non-crashed exits and guarded windows', async () => {
+  const { diagnostics } = await fresh()
+  const reloads = { count: 0 }
+  const win = makeFakeWindow(reloads)
+  diagnostics.attachWindow(win)
+
+  win.webContents.emit('render-process-gone', {}, { reason: 'killed', exitCode: 1 })
+  win.webContents.emit('render-process-gone', {}, { reason: 'abnormal-exit', exitCode: 1 })
+  assert.equal(reloads.count, 0)
+
+  const destroyed = makeFakeWindow(reloads)
+  destroyed.isDestroyed = () => true
+  diagnostics.attachWindow(destroyed)
+  crash(destroyed)
+  assert.equal(reloads.count, 0)
+
+  const noReload = new EventEmitter()
+  noReload.webContents = new EventEmitter()
+  noReload.isDestroyed = () => false
+  diagnostics.attachWindow(noReload)
+  crash(noReload) // must not throw despite missing reload
+  assert.equal(reloads.count, 0)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "lowlight": "^3.3.0",
         "markdown-it": "^14.1.0",
         "markdown-it-abbr": "^2.0.0",
+        "markdown-it-cjk-friendly": "^2.0.3",
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-emoji": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
@@ -780,7 +781,6 @@
       "integrity": "sha512-oKaoNeNtH2iIZMDFVrb1atoyRECDGHcfLMunJ5KWN8DtvpVBeeA4c41e20NTuhMxw1cSYbpq2PV2hb+/9CJxlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -896,7 +896,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -935,7 +934,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1222,6 +1220,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1243,6 +1242,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2313,7 +2313,6 @@
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -3150,7 +3149,6 @@
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3239,7 +3237,6 @@
       "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3655,7 +3652,6 @@
       "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3684,7 +3680,6 @@
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5103,7 +5098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5476,7 +5470,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5600,7 +5595,6 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6045,7 +6039,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6423,7 +6416,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -6679,6 +6671,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6699,6 +6692,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6714,6 +6708,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6724,6 +6719,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -7216,6 +7212,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7516,7 +7525,6 @@
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7944,7 +7952,6 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -8327,7 +8334,6 @@
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -8435,6 +8441,28 @@
       "integrity": "sha512-of7C8pXSjXjDojW4neNP+jD7inUYH/DO0Ca+K/4FUEccg0oHAEX/nfscw0jfz66PJbYWOAT9U8mjO21X5p6aAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/markdown-it-cjk-friendly": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/markdown-it-cjk-friendly/-/markdown-it-cjk-friendly-2.0.3.tgz",
+      "integrity": "sha512-dBAhqp7GZ6he15ug2t5JSfwTw2KvZX9tt0y7Up0reR1cZOBUogSq5V859hcIGwge7hjW1SkUaWkNr++0HszyZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/markdown-it": {
+          "optional": true
+        }
+      }
     },
     "node_modules/markdown-it-deflist": {
       "version": "3.0.0",
@@ -8673,6 +8701,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9162,7 +9191,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9267,7 +9295,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9305,6 +9332,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9322,6 +9350,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9633,7 +9662,6 @@
       "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9666,7 +9694,6 @@
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9719,7 +9746,6 @@
       "integrity": "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
@@ -9921,6 +9947,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10460,8 +10487,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10538,6 +10564,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10977,7 +11004,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11053,7 +11079,6 @@
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "lowlight": "^3.3.0",
     "markdown-it": "^14.1.0",
     "markdown-it-abbr": "^2.0.0",
+    "markdown-it-cjk-friendly": "^2.0.3",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-emoji": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import footnote from 'markdown-it-footnote'
 import sub from 'markdown-it-sub'
 import sup from 'markdown-it-sup'
 import abbr from 'markdown-it-abbr'
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
 import deflist from 'markdown-it-deflist'
 import ins from 'markdown-it-ins'
 import mark from 'markdown-it-mark'
@@ -1357,6 +1358,7 @@ const md = new MarkdownIt({
     return `<pre class="hljs"><code class="language-plaintext" data-code="${encoded}">${md.utils.escapeHtml(code)}</code></pre>`
   }
 })
+  .use(markdownItCjkFriendly)
   .use(emoji)
   .use(taskLists, { enabled: true, label: true, labelAfter: true })
   .use(footnote)

--- a/src/components/RichEditor.vue
+++ b/src/components/RichEditor.vue
@@ -36,6 +36,7 @@ import 'katex/dist/katex.min.css'
 import { Markdown } from 'tiptap-markdown'
 import markdownItMark from 'markdown-it-mark'
 import markdownItIns from 'markdown-it-ins'
+import markdownItCjkFriendly from 'markdown-it-cjk-friendly'
 import { toInternal, fromInternal } from '../lib/emptyRows.js'
 import { renderMermaid } from '../lib/mermaidRender.js'
 import { inferImageAlignment, inferImageSizing, migrateLegacyImageAlign, scaledImageCssWidth, serializeKnoteImage } from '../lib/imageMarkdown.js'
@@ -86,6 +87,10 @@ const MarkdownTweaks = Extension.create({
         parse: {
           setup(markdownit) {
             installKnoteMarkdownImagePolicy(markdownit)
+            // CJK-friendly emphasis: **加粗**直接紧贴汉字/全角标点是中文排版
+            // 默认写法，markdown-it 默认的 delimiter flanking 判定会把它当
+            // 字面文本（见 markdown-it-cjk-friendly 文档）
+            markdownit.use(markdownItCjkFriendly)
             markdownit.disable('reference')
             markdownit.use(markdownItMark) // ==highlight== -> <mark>
             markdownit.use(markdownItIns)  // ++underline++ -> <ins>


### PR DESCRIPTION
## 描述

两个独立改动（同一分支提交，可分别 review 或合并）：

### 1. fix(markdown): CJK-friendly 加粗/强调渲染（0f6572d）

**问题**：markdown-it 的 delimiter flanking 判定对中文排版不友好——中文习惯「加粗后直接紧贴汉字/全角标点、不加空格」：

- `**模块（Module）**信息` → 渲染为字面源码 `**模块（Module）**信息`
- `**Go语言（Golang）**是由**Google**设计` → 误配对为整段加粗（第一个 `**` 与最远 `**` 配对）
- 同一文本复制到有空格/换行的位置则正常

**根因**：Knote 使用 markdown-it ^14.1.0。其 delimiter 判定中，闭合 `**` 后紧跟汉字（CJK 非空白非 ASCII 标点）时无法作为 closer；内容以全角标点（如 `）`）结尾时同样被误判。已用标准 markdown-it 逐一复现全部现象（输出与 Knote 完全一致），确认非本项目魔改所致，而是库本身对中文排版的行为。

**修复**：在编辑器桥接（`src/components/RichEditor.vue` 的 tiptap-markdown parse setup）与预览渲染器（`src/App.vue`）两个 markdown-it 实例上应用社区成熟插件 `markdown-it-cjk-friendly@^2.0.3`（MIT，覆写 `md.inline.State.scanDelims` 增加 CJK 边界判定；VuePress 生态同方案）。同步更新 package-lock.json。

**验证**：8 组用例（失败样例 + 正常样例 + 行内公式 `$...$`）修复前后对照全部符合预期，公式渲染不受影响；`vite build` 通过。

### 2. feat(crash): 渲染进程崩溃后自动重载（457b144）

**问题**：渲染进程崩溃（STATUS_BREAKPOINT，0x80000003）后界面白屏且无任何自动恢复；此时退出被「存在未保存内容」拦截，用户只能从任务管理器强杀进程（存在丢失未保存内容的风险）。

**修复**（`electron/crash-diagnostics.cjs`）：

- `render-process-gone` 且 `reason === 'crashed'` 时自动 `webContents.reload()`，白屏后约 1-2 秒自动恢复；
- 护栏：60 秒冷却 + 累计最多 3 次，防止崩溃循环变成重载风暴；
- 恢复动作记入 `crash-diagnostics/events.jsonl`（新事件 `renderer-auto-recovered` + `attempt`）；
- `killed`/异常退出不触发（通常是系统回收或主动终止，不应自动重载）；窗口已销毁、无 reload 方法时安全跳过；
- 文档内容近实时写盘（retention store），重载最多丢失最后 debounce 窗口的输入。

**验证**：

- 单元测试 12/12（含新增 3 个恢复用例：触发+审计事件、冷却去重、上限停止、非 crashed 不触发、销毁/缺失防御）；
- `npm run test:crash` 25/25（含 main-lifecycle、quit-cleanup 零回归）；
- 真实 Electron demo（复用本文件，`forcefullyCrashRenderer()` ×4 间隔 61s + `taskkill` 渲染进程）：crashed → 自动重载 ×3、第 4 次超上限停止、killed 不触发，events.jsonl 记录完整。

## 提交列表

```
0f6572d fix(markdown): CJK-friendly emphasis for bold adjacent to CJK chars/fullwidth punctuation
457b144 feat(crash): auto-reload the window after a renderer crash (guarded)
c70fc39 chore: sync package-lock for markdown-it-cjk-friendly
```

## 备注

- 不引入运行时新依赖以外的改动；渲染层（Vue/Tiptap）未修改。
- 崩溃自动恢复为独立可回退改动（删除 `_maybeAutoRecover` 即可）。
