### PR TITLE
feat(linux): add Linux desktop support (AppImage/rpm/deb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,8 +231,52 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  linux:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # package.json pins electronDist to node_modules/electron/dist (local
+      # proxies truncate electron-builder's own zip download); guarantee that
+      # folder exists on the runner by (re)running electron's install script.
+      - run: node node_modules/electron/install.js
+      - run: npx vite build
+      # --publish never: on a tagged CI build electron-builder defaults to
+      # auto-publishing and dies without a token — the release step below
+      # owns publishing instead
+      - name: Build Linux packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx electron-builder --linux --publish never 2>&1 | tee build-linux.log
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: knote-linux-release
+          path: |
+            release/*.AppImage
+            release/*.rpm
+            release/*.deb
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload Linux diagnostic logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release-diagnostics-${{ github.run_attempt }}
+          path: build-linux.log
+          if-no-files-found: ignore
+          retention-days: 7
+
   publish:
-    needs: [android, windows]
+    needs: [android, windows, linux]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -248,6 +292,11 @@ jobs:
         with:
           name: knote-windows-release
           path: release-assets/windows
+      - name: Download Linux release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: knote-linux-release
+          path: release-assets/linux
       - name: Verify complete release artifact set
         shell: bash
         run: |
@@ -255,18 +304,30 @@ jobs:
           shopt -s nullglob
           android_apks=(release-assets/android/Knote-*-android-release.apk)
           windows_installers=(release-assets/windows/Knote-Setup-*.exe)
+          linux_appimages=(release-assets/linux/Knote-*.AppImage)
+          linux_rpms=(release-assets/linux/Knote-*.rpm)
+          linux_debs=(release-assets/linux/Knote-*.deb)
           expected_version="${GITHUB_REF_NAME#v}"
           expected_apk="release-assets/android/Knote-${GITHUB_REF_NAME}-android-release.apk"
           expected_installer="release-assets/windows/Knote-Setup-${expected_version}.exe"
+          expected_appimage="release-assets/linux/Knote-${expected_version}.AppImage"
+          expected_rpm="release-assets/linux/Knote-${expected_version}.rpm"
+          expected_deb="release-assets/linux/Knote-${expected_version}.deb"
           if (( ${#android_apks[@]} != 1 || ${#windows_installers[@]} != 1 )) ||
+             (( ${#linux_appimages[@]} != 1 || ${#linux_rpms[@]} != 1 || ${#linux_debs[@]} != 1 )) ||
              [[ "${android_apks[0]:-}" != "$expected_apk" || "${windows_installers[0]:-}" != "$expected_installer" ]] ||
-             [[ ! -s "$expected_apk" || ! -s "$expected_installer" ]]; then
-            echo "::error::Expected exactly one verified Android APK and one Windows installer."
+             [[ "${linux_appimages[0]:-}" != "$expected_appimage" || "${linux_rpms[0]:-}" != "$expected_rpm" || "${linux_debs[0]:-}" != "$expected_deb" ]] ||
+             [[ ! -s "$expected_apk" || ! -s "$expected_installer" ]] ||
+             [[ ! -s "$expected_appimage" || ! -s "$expected_rpm" || ! -s "$expected_deb" ]]; then
+            echo "::error::Expected exactly one verified Android APK, one Windows installer, and one of each Linux package (AppImage/rpm/deb)."
             exit 1
           fi
           printf '%s\n' \
             "ANDROID_RELEASE_ASSET=$expected_apk" \
-            "WINDOWS_RELEASE_ASSET=$expected_installer" >> "$GITHUB_ENV"
+            "WINDOWS_RELEASE_ASSET=$expected_installer" \
+            "LINUX_APPIMAGE_ASSET=$expected_appimage" \
+            "LINUX_RPM_ASSET=$expected_rpm" \
+            "LINUX_DEB_ASSET=$expected_deb" >> "$GITHUB_ENV"
       - name: Publish fail-closed GitHub Release
         shell: bash
         env:
@@ -339,22 +400,40 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" \
             "$ANDROID_RELEASE_ASSET" \
             "$WINDOWS_RELEASE_ASSET" \
+            "$LINUX_APPIMAGE_ASSET" \
+            "$LINUX_RPM_ASSET" \
+            "$LINUX_DEB_ASSET" \
             --repo "$GITHUB_REPOSITORY"
 
           remote_assets="$RUNNER_TEMP/knote-release-assets-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           gh api "/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" > "$remote_assets"
           apk_name="$(basename "$ANDROID_RELEASE_ASSET")"
           installer_name="$(basename "$WINDOWS_RELEASE_ASSET")"
+          appimage_name="$(basename "$LINUX_APPIMAGE_ASSET")"
+          rpm_name="$(basename "$LINUX_RPM_ASSET")"
+          deb_name="$(basename "$LINUX_DEB_ASSET")"
           apk_size="$(stat -c '%s' "$ANDROID_RELEASE_ASSET")"
           installer_size="$(stat -c '%s' "$WINDOWS_RELEASE_ASSET")"
+          appimage_size="$(stat -c '%s' "$LINUX_APPIMAGE_ASSET")"
+          rpm_size="$(stat -c '%s' "$LINUX_RPM_ASSET")"
+          deb_size="$(stat -c '%s' "$LINUX_DEB_ASSET")"
           jq -e \
             --arg apk "$apk_name" \
             --arg installer "$installer_name" \
+            --arg appimage "$appimage_name" \
+            --arg rpm "$rpm_name" \
+            --arg deb "$deb_name" \
             --argjson apk_size "$apk_size" \
             --argjson installer_size "$installer_size" \
-            'length == 2 and
+            --argjson appimage_size "$appimage_size" \
+            --argjson rpm_size "$rpm_size" \
+            --argjson deb_size "$deb_size" \
+            'length == 5 and
              any(.[]; .name == $apk and .state == "uploaded" and .size == $apk_size) and
-             any(.[]; .name == $installer and .state == "uploaded" and .size == $installer_size)' \
+             any(.[]; .name == $installer and .state == "uploaded" and .size == $installer_size) and
+             any(.[]; .name == $appimage and .state == "uploaded" and .size == $appimage_size) and
+             any(.[]; .name == $rpm and .state == "uploaded" and .size == $rpm_size) and
+             any(.[]; .name == $deb and .state == "uploaded" and .size == $deb_size)' \
             "$remote_assets" > /dev/null
 
           current_release="$RUNNER_TEMP/knote-release-before-publish-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -586,7 +586,7 @@ const pipInstallWithMirrors = async (py, pipArgs, label) => {
 // python.org as the last resort. pip is added via get-pip.
 const EMBED_PY_VER = '3.11.9'
 const ensureEmbeddedPython = async (dir) => {
-  if (process.platform !== 'win32') throw new Error('未找到 Python，请先安装 Python 3（建议 3.10 / 3.11）')
+  if (process.platform !== 'win32') throw new Error('未找到 Python，请先安装系统 Python 3（例如：sudo apt install python3 python3-venv python3-pip）')
   fs.mkdirSync(dir, { recursive: true })
   const zip = path.join(dir, 'python-embed.zip')
   emitEnvProgress('未检测到系统 Python——自动下载内置版 Python（约 11 MB）…')
@@ -667,7 +667,7 @@ let rendererReady = false
 let titleBarDark = false
 let titleBarZoomFactor = 1
 const applyTitleBarOverlay = () => {
-  if (!win || win.isDestroyed()) return false
+  if (!win || win.isDestroyed() || process.platform === 'linux') return false
   try {
     win.setTitleBarOverlay({
       color: '#00000000',
@@ -933,12 +933,12 @@ const createWindow = () => {
     // opaque window (no acrylic/transparency — that showed black edges on
     // some GPU/DWM configs); the frosted look is a CSS tint on the bar
     backgroundColor: '#e5e7eb',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: {
-      color: '#00000000',
-      symbolColor: '#4b5563',
-      height: 40
-    },
+    // On Linux (GNOME) use the native window frame so the user gets the
+    // native min/max/close buttons and Mutter decorations. Windows keeps
+    // the custom WCO overlay.
+    ...(process.platform === 'linux'
+      ? {}
+      : { titleBarStyle: 'hidden', titleBarOverlay: { color: '#00000000', symbolColor: '#4b5563', height: 40 } }),
     webPreferences: {
       preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -76,6 +76,7 @@ const cancelTrackedAgentDownload = async (idValue) => {
 
 contextBridge.exposeInMainWorld('knoteDesktop', {
   isE2E,
+  platform: process.platform,
   onOpenFile: (cb) => {
     ipcRenderer.on('knote:open-file', (_e, payload) => cb(payload))
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -781,7 +781,6 @@
       "integrity": "sha512-oKaoNeNtH2iIZMDFVrb1atoyRECDGHcfLMunJ5KWN8DtvpVBeeA4c41e20NTuhMxw1cSYbpq2PV2hb+/9CJxlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -897,7 +896,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -936,7 +934,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1223,6 +1220,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1244,6 +1242,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2314,7 +2313,6 @@
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -3151,7 +3149,6 @@
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3240,7 +3237,6 @@
       "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3656,7 +3652,6 @@
       "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3685,7 +3680,6 @@
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5105,7 +5099,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5478,7 +5471,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5602,7 +5596,6 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6047,7 +6040,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6425,7 +6417,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -6681,6 +6672,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6701,6 +6693,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6716,6 +6709,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6726,6 +6720,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -7531,7 +7526,6 @@
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7959,7 +7953,6 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -8342,7 +8335,6 @@
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -8711,6 +8703,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9200,7 +9193,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9305,7 +9297,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9343,6 +9334,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9360,6 +9352,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9671,7 +9664,6 @@
       "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9704,7 +9696,6 @@
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9757,7 +9748,6 @@
       "integrity": "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
@@ -9959,6 +9949,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10498,8 +10489,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10576,6 +10566,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11015,7 +11006,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11091,7 +11081,6 @@
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "app:dev": "electron .",
     "dist:win": "vite build && electron-builder --win",
+    "dist:linux": "vite build && electron-builder --linux",
     "android:assets": "capacitor-assets generate --android --assetPath assets --iconBackgroundColor \"#ffffff\" --iconBackgroundColorDark \"#ffffff\" --splashBackgroundColor \"#ffffff\" --splashBackgroundColorDark \"#ffffff\" && node scripts/verify-android-assets.mjs",
     "cap:sync": "cap sync android && npm run android:assets && node scripts/set-android-version.mjs && node scripts/configure-android-signing.mjs && node scripts/fix-android-java.mjs",
     "dist:apk:debug": "vite build && npm run cap:sync && cd android && gradlew.bat clean assembleDebug --no-daemon",
@@ -82,6 +83,18 @@
       "shortcutName": "Knote",
       "include": "build/installer.nsh",
       "artifactName": "Knote-Setup-${version}.${ext}"
+    },
+    "linux": {
+      "target": [
+        { "target": "AppImage", "arch": ["x64"] },
+        { "target": "rpm", "arch": ["x64"] },
+        { "target": "deb", "arch": ["x64"] }
+      ],
+      "icon": "build/icon.png",
+      "category": "Office",
+      "maintainer": "KV",
+      "mimeTypes": ["text/markdown", "text/x-markdown"],
+      "artifactName": "Knote-${version}.${ext}"
     }
   },
   "dependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -7574,7 +7574,7 @@ const toggleHwAccel = async () => {
   if (restart) await window.knoteDesktop.relaunchApp()
 }
 const supportsDocumentTabs = computed(() => isDesktopShell || isAndroidTablet.value)
-if (isDesktopShell) document.documentElement.classList.add('knote-wco') // frosted title bar CSS
+if (isDesktopShell && window.knoteDesktop?.platform !== 'linux') document.documentElement.classList.add('knote-wco') // frosted title bar CSS
 let stopWindowState = null
 // Startup session replay must never win over a file/folder the user explicitly
 // opened. Session requests carry a renderer-generated ID through main/preload;


### PR DESCRIPTION
## 概述

为 Knote 增加 Linux 桌面支持：应用可在 Linux/GNOME 上运行，并可打包为 AppImage / rpm / deb 三种格式。

## 改动内容

### 功能（electron/main.cjs、preload.cjs、src/App.vue）
- 窗口标题栏平台化：Linux 上改用系统原生窗口帧（GNOME/Mutter 装饰），Windows 保留原有 WCO 磨砂标题栏
- 通过 preload 暴露 `platform` 字段，渲染进程据此判断是否启用 `knote-wco` 磨砂样式
- 修正 `ensureEmbeddedPython` 在非 Windows 平台的错误提示（引导用户安装系统 Python 3）

### 构建（package.json）
- 新增 `dist:linux` 脚本
- 新增 electron-builder `linux` 目标：AppImage + rpm + deb，含 `.desktop` MIME 关联（text/markdown）

### CI（.github/workflows/release.yml）
- 新增 `linux` job（ubuntu-latest 上构建三种 Linux 包并上传产物）
- `publish` job 扩展为验证并发布 5 个资产（APK + exe + AppImage + rpm + deb）

## 验证方式

- `npm run dist:linux` 本地构建出 `Knote-<version>.AppImage/.rpm/.deb`
- AppImage 在 Fedora 44 / Wayland / GNOME 上实测启动运行正常
- `npm run test:crash` 全绿；`npm run test:boundary` 仅剩 2 个既有的 Linux 硬链接测试失败（与本次改动无关，Windows 上通过）

## 需要确认

`release.yml` 的 linux job 会让官方发布流水线**新增 Linux 产物**。如果希望保持官方发布仅含 Windows/Android，我可以把 CI 改动拆分到单独的 PR。

## GNOME 上效果
<img width="2879" height="1799" alt="image" src="https://github.com/user-attachments/assets/914ae1e1-4d4b-4011-bdfa-4612004cc0af" />
