### PR TITLE
feat: 分栏源码代码块智能编辑 + 悬浮侧边栏方向可配 + 自动保存（默认开/可关/间隔可调）+ 保存状态灯修正

### DIFF
--- a/scripts/electron-ui.e2e.test.mjs
+++ b/scripts/electron-ui.e2e.test.mjs
@@ -8567,8 +8567,11 @@ test('floating split sidebar slides from the left by default and mirrors to the 
   assert.equal(await actionsCard.isVisible(), false, 'left edge must not open the panel when side=right')
 })
 
-test('unsaved-changes lamp turns amber on edit and back to green after save (autosave off by default)', async (t) => {
+test('unsaved-changes lamp turns amber on edit and back to green after save (when auto-save is off)', async (t) => {
   const { page, workspace } = await launchFixture(t)
+  // auto-save is ON by default — flip it off to exercise the manual model
+  await page.evaluate(() => localStorage.setItem('knote-autosave-enabled-v1', '0'))
+  await page.reload()
   await workspaceTreeRow(page, 'keep.md').click()
   const pm = page.locator('.ProseMirror').first()
   await pm.waitFor({ state: 'visible', timeout: 15_000 })
@@ -8588,9 +8591,9 @@ test('unsaved-changes lamp turns amber on edit and back to green after save (aut
   await badge.waitFor({ state: 'visible', timeout: 5_000 })
   assert.equal(await fileName.isVisible(), false, 'unsaved state must not claim the file is clean')
 
-  // auto-save is OFF by default: nothing writes the disk on its own
+  // with auto-save switched off nothing writes the disk on its own
   await page.waitForTimeout(1500)
-  assert.equal(fs.readFileSync(keepPath, 'utf8'), '# Keep\n', 'default mode must keep saving manual')
+  assert.equal(fs.readFileSync(keepPath, 'utf8'), '# Keep\n', 'switched-off auto-save must keep saving manual')
 
   // Ctrl+S (the real save path) clears the lamp and lands the text on disk
   await page.keyboard.press('Control+s')
@@ -8602,10 +8605,10 @@ test('unsaved-changes lamp turns amber on edit and back to green after save (aut
   assert.equal(await fileName.isVisible(), true, 'lamp back to green shows the file name')
 })
 
-test('auto-save clock saves the current file at the configured interval when enabled', async (t) => {
+test('auto-save debounce saves the current file after the configured pause when enabled', async (t) => {
   const { page, workspace } = await launchFixture(t)
   const keepPath = path.join(workspace, 'keep.md')
-  // opt in with a fast 2s interval (the menu minimum is 5s; storage accepts 1+)
+  // a 2s debounce is fast enough to wait for (the default is 1s / on)
   await page.evaluate(() => {
     localStorage.setItem('knote-autosave-enabled-v1', '1')
     localStorage.setItem('knote-autosave-interval-v1', '2')
@@ -8618,52 +8621,50 @@ test('auto-save clock saves the current file at the configured interval when ena
   const indicator = page.getByTestId('autosave-indicator')
   await indicator.waitFor({ state: 'visible', timeout: 5_000 })
 
-  // edit → amber, then the clock saves it back to green on its own (no key)
+  // edit → amber, then the debounce saves it back to green on its own (no key)
   await pm.click()
   await page.keyboard.press('End')
   await page.keyboard.type(' AUTO_SAVED')
   await badge.waitFor({ state: 'visible', timeout: 5_000 })
   await waitUntil(() => fs.readFileSync(keepPath, 'utf8').includes('AUTO_SAVED'), {
     timeout: 8_000,
-    message: 'auto-save clock did not write the edit'
+    message: 'auto-save debounce did not write the edit'
   })
   await waitUntil(async () => (await badge.count()) === 0, { timeout: 5_000, message: 'lamp stayed amber after the auto-save' })
 })
 
-test('auto-save interval is editable in the menu and the clock follows the new value', async (t) => {
+test('auto-save interval is editable in the menu and the debounce follows the new value', async (t) => {
   const { page, workspace } = await launchFixture(t)
   await workspaceTreeRow(page, 'keep.md').click()
   const pm = page.locator('.ProseMirror').first()
   await pm.waitFor({ state: 'visible', timeout: 15_000 })
   const keepPath = path.join(workspace, 'keep.md')
 
-  // turn the feature on through the real navbar menu
+  // auto-save is ON by default: the indicator is already lit in the navbar
+  await page.getByTestId('autosave-indicator').waitFor({ state: 'visible', timeout: 5_000 })
+
+  // open the menu: the toggle is checked and the interval field shows 1s
   await page.getByTestId('actions-menu').click()
   const toggle = page.getByTestId('autosave-toggle')
   await toggle.waitFor({ state: 'visible', timeout: 5_000 })
-  assert.equal(await toggle.getAttribute('aria-checked'), 'false', 'auto-save defaults to off')
-  await toggle.click()
-  assert.equal(await toggle.getAttribute('aria-checked'), 'true', 'menu toggle enables auto-save')
-  await page.getByTestId('autosave-indicator').waitFor({ state: 'visible', timeout: 5_000 })
-
-  // the interval field appears while on; edit it to 2s (default is 10s)
+  assert.equal(await toggle.getAttribute('aria-checked'), 'true', 'auto-save defaults to on')
   const intervalInput = page.getByTestId('autosave-interval-input')
   await intervalInput.waitFor({ state: 'visible', timeout: 5_000 })
-  assert.equal(await intervalInput.inputValue(), '10', 'interval defaults to 10 seconds')
+  assert.equal(await intervalInput.inputValue(), '1', 'interval defaults to 1 second')
   await intervalInput.fill('2')
   assert.equal(
     await page.evaluate(() => localStorage.getItem('knote-autosave-interval-v1')),
     '2',
     'edited interval must persist'
   )
-  // close the menu, edit, and let the (now 2s) clock save on its own
+  // close the menu, edit, and let the (now 2s) debounce save on its own
   await pm.click()
   await page.keyboard.press('End')
   await page.keyboard.type(' INTERVAL_EDIT')
   await page.getByTestId('unsaved-changes-badge').waitFor({ state: 'visible', timeout: 5_000 })
-  // 8s < the old 10s default: only the edited 2s interval can save in time
+  // 8s comfortably covers the 2s debounce after typing stops
   await waitUntil(() => fs.readFileSync(keepPath, 'utf8').includes('INTERVAL_EDIT'), {
     timeout: 8_000,
-    message: 'clock did not follow the edited interval'
+    message: 'debounce did not follow the edited interval'
   })
 })

--- a/scripts/electron-ui.e2e.test.mjs
+++ b/scripts/electron-ui.e2e.test.mjs
@@ -8535,24 +8535,23 @@ test('floating split sidebar slides from the left by default and mirrors to the 
   let box = await actionsCard.boundingBox()
   assert.ok(box.x < 40, 'default panel must hug the left screen edge')
 
-  // --- toggle the setting from the panel menu (persisted + effective at once)
+  // --- toggle the setting from the panel menu: the click itself must dismiss
+  // the menu AND retract the panel on its current (left) side
   await page.getByTestId('floating-actions-menu').click()
   const sideToggle = page.getByTestId('floating-sidebar-side-float')
   await sideToggle.waitFor({ state: 'visible', timeout: 5_000 })
   assert.equal(await sideToggle.getAttribute('aria-checked'), 'false', 'side toggle starts unchecked (left)')
   await sideToggle.click()
-  assert.equal(await sideToggle.getAttribute('aria-checked'), 'true', 'side toggle checked after click')
   assert.equal(
     await page.evaluate(() => localStorage.getItem('knote-floating-sidebar-right-v1')),
     '1',
     'side choice must persist to localStorage'
   )
-  assert.equal(await edgeIsRight(), true, 'edge flips to the right immediately')
-  // close the popup menu by clicking its outside overlay (the ⋯ button would
-  // just re-open it), then leave the panel so it slides away
-  await page.mouse.click(350, 500)
+  assert.equal(await sideToggle.isVisible(), false, 'the menu closes on toggle')
+  // panel retracts on the left side, then the edge flips right
+  await waitUntil(async () => !(await actionsCard.isVisible()), { timeout: 5_000, message: 'panel must retract when the side flips' })
+  await waitUntil(async () => (await edgeIsRight()) === true, { timeout: 5_000, message: 'edge flips to the right after the retract' })
   await page.mouse.move(Math.round(viewport.width / 2), Math.round(viewport.height / 2))
-  await page.waitForTimeout(700)
 
   // --- now the RIGHT edge is the recall zone and the panel hugs the right
   await page.mouse.move(viewport.width - 3, Math.round(viewport.height / 2))

--- a/scripts/electron-ui.e2e.test.mjs
+++ b/scripts/electron-ui.e2e.test.mjs
@@ -8412,7 +8412,7 @@ test('source smart editing: list/quote continuation and selection surround in sp
     return content.includes('strike me') && !content.includes('~~')
   }, { timeout: 5_000, message: 'second Ctrl+Shift+X did not unwrap ~~' })
 
-  // inside a code fence every smart edit is skipped (plain Enter)
+  // inside a code fence the markdown list continuation stays off …
   await resetDoc('```js\n- code\n```\n')
   await placeCaret('- code')
   await page.keyboard.press('Enter')
@@ -8420,6 +8420,98 @@ test('source smart editing: list/quote continuation and selection surround in sp
   assert.equal(
     await page.evaluate(() => !window.__knoteDebug.getContent().includes('- code\n- ')),
     true,
-    'fence-internal Enter must stay a plain newline'
+    'fence-internal Enter must not continue the markdown list'
   )
+
+  // … but IDE-like editing kicks in: typing ( auto-pairs with the caret inside
+  await resetDoc('```js\ncode\n```\n')
+  await placeCaret('code')
+  await page.keyboard.type('(')
+  await waitUntil(() => contentHas('code()'), { timeout: 5_000, message: 'open paren did not auto-close in the fence' })
+  await page.keyboard.type('x')
+  await waitUntil(() => contentHas('code(x)'), { timeout: 5_000, message: 'caret was not inside the auto-paired ()' })
+
+  // quotes auto-pair inside the fence …
+  await resetDoc('```js\ns\n```\n')
+  await placeCaret('\ns') // line 2 — ````js```` itself also contains an 's'
+  await page.keyboard.type('"')
+  await waitUntil(() => contentHas('s""'), { timeout: 5_000, message: 'double quote did not auto-pair in the fence' })
+  await page.keyboard.type('v')
+  await waitUntil(() => contentHas('s"v"'), { timeout: 5_000, message: 'caret was not inside the auto-paired quotes' })
+  // … and one more " press overtypes the closing quote instead of doubling it
+  await resetDoc('```js\n"hi"\n```\n')
+  await placeCaret('hi')
+  await page.keyboard.type('"')
+  await page.keyboard.type(';')
+  await waitUntil(() => contentHas('"hi";'), { timeout: 5_000, message: 'closing quote was doubled instead of overtyped' })
+
+  // Enter keeps the indentation inside the fence
+  await resetDoc('```js\n    let a = 1\n```\n')
+  await placeCaret('let a = 1')
+  await page.keyboard.press('Enter')
+  await waitUntil(() => contentHas('    let a = 1\n    '), { timeout: 5_000, message: 'fence Enter did not keep the line indent' })
+  // Enter inside an unclosed bracket group indents one extra level
+  await resetDoc('```js\nfoo(\n```\n')
+  await placeCaret('foo(')
+  await page.keyboard.press('Enter')
+  await waitUntil(() => contentHas('foo(\n    '), { timeout: 5_000, message: 'fence Enter did not deepen inside brackets' })
+  // Enter inside an EMPTY pair pushes the closer onto its own line
+  await resetDoc('```js\nint main() {}\n```\n')
+  await placeCaret('{')
+  await page.keyboard.press('Enter')
+  await waitUntil(() => contentHas('int main() {\n    \n}'), { timeout: 5_000, message: 'fence Enter did not split the empty pair' })
+
+  // Tab indents inside the fence (a 4-space level)
+  await resetDoc('```js\nx\n```\n')
+  await placeCaret('\n')
+  await page.keyboard.press('Tab')
+  await waitUntil(() => contentHas('\n    x\n'), { timeout: 5_000, message: 'Tab did not indent inside the fence' })
+
+  // outside the fence quotes still stay literal (plain-text editing intact)
+  await resetDoc('say\n')
+  await placeCaret('say')
+  await page.keyboard.type('"')
+  await waitUntil(() => contentHas('say"'), { timeout: 5_000, message: 'quote outside the fence must stay literal' })
+  const doubled = await page.evaluate(() => window.__knoteDebug.getContent().includes('say""'))
+  assert.equal(doubled, false, 'quote outside the fence must not auto-close')
+})
+
+test('source smart editing stays plain text when the toggle is off (default)', async (t) => {
+  const { page } = await launchFixture(t)
+  await workspaceTreeRow(page, 'keep.md').click()
+  // the toggle defaults to off — do NOT set the localStorage flag
+  await page.locator('.knote-view-toggle button').nth(1).click() // split view
+  const editor = page.getByTestId('markdown-source-editor')
+  await editor.waitFor({ state: 'attached' })
+  const contentHas = (fragment) => page.evaluate((needle) => window.__knoteDebug.getContent().includes(needle), fragment)
+  const placeCaret = async (fragment) => {
+    await page.evaluate((frag) => {
+      const el = document.querySelector('[data-testid="markdown-source-editor"]')
+      const caret = el.value.indexOf(frag) + frag.length
+      el.focus()
+      el.setSelectionRange(caret, caret)
+    }, fragment)
+  }
+  await page.evaluate(async (md) => {
+    const agent = await window.__knoteDebug.agent()
+    agent.agentBridge.applyMarkdown(md)
+  }, '```js\ncode\n```\n')
+  await editor.click()
+  // ( typed inside the fence stays a literal open paren (no auto-close)
+  await placeCaret('code')
+  await page.keyboard.type('(')
+  await waitUntil(() => contentHas('code('), { timeout: 5_000, message: 'off: ( should type literally' })
+  const paired = await page.evaluate(() => window.__knoteDebug.getContent().includes('code()'))
+  assert.equal(paired, false, 'off: ( must not auto-pair inside the fence')
+  // Enter inside the fence stays a plain newline (no auto-indent)
+  await page.evaluate(async (md) => {
+    const agent = await window.__knoteDebug.agent()
+    agent.agentBridge.applyMarkdown(md)
+  }, '```js\n    x\n```\n')
+  await editor.click()
+  await placeCaret('x')
+  await page.keyboard.press('Enter')
+  await page.waitForTimeout(300)
+  const indented = await page.evaluate(() => window.__knoteDebug.getContent().includes('    x\n    '))
+  assert.equal(indented, false, 'off: fence Enter must not auto-indent')
 })

--- a/scripts/electron-ui.e2e.test.mjs
+++ b/scripts/electron-ui.e2e.test.mjs
@@ -8515,3 +8515,55 @@ test('source smart editing stays plain text when the toggle is off (default)', a
   const indented = await page.evaluate(() => window.__knoteDebug.getContent().includes('    x\n    '))
   assert.equal(indented, false, 'off: fence Enter must not auto-indent')
 })
+
+test('floating split sidebar slides from the left by default and mirrors to the right via the setting', async (t) => {
+  const { page } = await launchFixture(t)
+  await workspaceTreeRow(page, 'keep.md').click()
+  await page.locator('.knote-view-toggle button').nth(1).click() // split view
+  const actionsCard = page.getByTestId('floating-actions-card')
+  const edgeIsRight = () => page.evaluate(() => {
+    const edge = document.querySelector('.knote-floating-edge')
+    return edge ? edge.classList.contains('right-0') : null
+  })
+  const viewport = page.viewportSize()
+
+  // --- default (no setting): hover the LEFT edge → panel pinned to the left
+  assert.equal(await edgeIsRight(), false, 'default edge must sit on the left')
+  await page.mouse.move(3, Math.round(viewport.height / 2))
+  await actionsCard.waitFor({ state: 'visible', timeout: 5_000 })
+  await page.waitForTimeout(450) // let the slide-in transition finish
+  let box = await actionsCard.boundingBox()
+  assert.ok(box.x < 40, 'default panel must hug the left screen edge')
+
+  // --- toggle the setting from the panel menu (persisted + effective at once)
+  await page.getByTestId('floating-actions-menu').click()
+  const sideToggle = page.getByTestId('floating-sidebar-side-float')
+  await sideToggle.waitFor({ state: 'visible', timeout: 5_000 })
+  assert.equal(await sideToggle.getAttribute('aria-checked'), 'false', 'side toggle starts unchecked (left)')
+  await sideToggle.click()
+  assert.equal(await sideToggle.getAttribute('aria-checked'), 'true', 'side toggle checked after click')
+  assert.equal(
+    await page.evaluate(() => localStorage.getItem('knote-floating-sidebar-right-v1')),
+    '1',
+    'side choice must persist to localStorage'
+  )
+  assert.equal(await edgeIsRight(), true, 'edge flips to the right immediately')
+  // close the popup menu by clicking its outside overlay (the ⋯ button would
+  // just re-open it), then leave the panel so it slides away
+  await page.mouse.click(350, 500)
+  await page.mouse.move(Math.round(viewport.width / 2), Math.round(viewport.height / 2))
+  await page.waitForTimeout(700)
+
+  // --- now the RIGHT edge is the recall zone and the panel hugs the right
+  await page.mouse.move(viewport.width - 3, Math.round(viewport.height / 2))
+  await actionsCard.waitFor({ state: 'visible', timeout: 5_000 })
+  await page.waitForTimeout(450) // let the slide-in transition finish
+  box = await actionsCard.boundingBox()
+  assert.ok(viewport.width - (box.x + box.width) < 40, 'mirrored panel must hug the right screen edge')
+  // and the LEFT edge no longer triggers it
+  await page.mouse.move(Math.round(viewport.width / 2), Math.round(viewport.height / 2))
+  await page.waitForTimeout(700)
+  await page.mouse.move(3, Math.round(viewport.height / 2))
+  await page.waitForTimeout(700)
+  assert.equal(await actionsCard.isVisible(), false, 'left edge must not open the panel when side=right')
+})

--- a/scripts/electron-ui.e2e.test.mjs
+++ b/scripts/electron-ui.e2e.test.mjs
@@ -8567,3 +8567,104 @@ test('floating split sidebar slides from the left by default and mirrors to the 
   await page.waitForTimeout(700)
   assert.equal(await actionsCard.isVisible(), false, 'left edge must not open the panel when side=right')
 })
+
+test('unsaved-changes lamp turns amber on edit and back to green after save (autosave off by default)', async (t) => {
+  const { page, workspace } = await launchFixture(t)
+  await workspaceTreeRow(page, 'keep.md').click()
+  const pm = page.locator('.ProseMirror').first()
+  await pm.waitFor({ state: 'visible', timeout: 15_000 })
+  const keepPath = path.join(workspace, 'keep.md')
+  const badge = page.getByTestId('unsaved-changes-badge')
+  const fileName = page.getByTestId('current-file-name')
+
+  // freshly opened + untouched → green lamp shows the file name, no badge
+  assert.equal(await badge.count(), 0, 'a saved file must not show the unsaved badge')
+  assert.equal(await fileName.isVisible(), true, 'saved state shows the file name')
+  assert.equal(fs.readFileSync(keepPath, 'utf8'), '# Keep\n')
+
+  // edit → the lamp must turn amber immediately with an unsaved hint
+  await pm.click()
+  await page.keyboard.press('End')
+  await page.keyboard.type(' edited')
+  await badge.waitFor({ state: 'visible', timeout: 5_000 })
+  assert.equal(await fileName.isVisible(), false, 'unsaved state must not claim the file is clean')
+
+  // auto-save is OFF by default: nothing writes the disk on its own
+  await page.waitForTimeout(1500)
+  assert.equal(fs.readFileSync(keepPath, 'utf8'), '# Keep\n', 'default mode must keep saving manual')
+
+  // Ctrl+S (the real save path) clears the lamp and lands the text on disk
+  await page.keyboard.press('Control+s')
+  await waitUntil(() => fs.readFileSync(keepPath, 'utf8').includes('edited'), {
+    timeout: 5_000,
+    message: 'Ctrl+S did not write the file'
+  })
+  await waitUntil(async () => (await badge.count()) === 0, { timeout: 5_000, message: 'lamp stayed amber after save' })
+  assert.equal(await fileName.isVisible(), true, 'lamp back to green shows the file name')
+})
+
+test('auto-save clock saves the current file at the configured interval when enabled', async (t) => {
+  const { page, workspace } = await launchFixture(t)
+  const keepPath = path.join(workspace, 'keep.md')
+  // opt in with a fast 2s interval (the menu minimum is 5s; storage accepts 1+)
+  await page.evaluate(() => {
+    localStorage.setItem('knote-autosave-enabled-v1', '1')
+    localStorage.setItem('knote-autosave-interval-v1', '2')
+  })
+  await page.reload()
+  await workspaceTreeRow(page, 'keep.md').click()
+  const pm = page.locator('.ProseMirror').first()
+  await pm.waitFor({ state: 'visible', timeout: 15_000 })
+  const badge = page.getByTestId('unsaved-changes-badge')
+  const indicator = page.getByTestId('autosave-indicator')
+  await indicator.waitFor({ state: 'visible', timeout: 5_000 })
+
+  // edit → amber, then the clock saves it back to green on its own (no key)
+  await pm.click()
+  await page.keyboard.press('End')
+  await page.keyboard.type(' AUTO_SAVED')
+  await badge.waitFor({ state: 'visible', timeout: 5_000 })
+  await waitUntil(() => fs.readFileSync(keepPath, 'utf8').includes('AUTO_SAVED'), {
+    timeout: 8_000,
+    message: 'auto-save clock did not write the edit'
+  })
+  await waitUntil(async () => (await badge.count()) === 0, { timeout: 5_000, message: 'lamp stayed amber after the auto-save' })
+})
+
+test('auto-save interval is editable in the menu and the clock follows the new value', async (t) => {
+  const { page, workspace } = await launchFixture(t)
+  await workspaceTreeRow(page, 'keep.md').click()
+  const pm = page.locator('.ProseMirror').first()
+  await pm.waitFor({ state: 'visible', timeout: 15_000 })
+  const keepPath = path.join(workspace, 'keep.md')
+
+  // turn the feature on through the real navbar menu
+  await page.getByTestId('actions-menu').click()
+  const toggle = page.getByTestId('autosave-toggle')
+  await toggle.waitFor({ state: 'visible', timeout: 5_000 })
+  assert.equal(await toggle.getAttribute('aria-checked'), 'false', 'auto-save defaults to off')
+  await toggle.click()
+  assert.equal(await toggle.getAttribute('aria-checked'), 'true', 'menu toggle enables auto-save')
+  await page.getByTestId('autosave-indicator').waitFor({ state: 'visible', timeout: 5_000 })
+
+  // the interval field appears while on; edit it to 2s (default is 10s)
+  const intervalInput = page.getByTestId('autosave-interval-input')
+  await intervalInput.waitFor({ state: 'visible', timeout: 5_000 })
+  assert.equal(await intervalInput.inputValue(), '10', 'interval defaults to 10 seconds')
+  await intervalInput.fill('2')
+  assert.equal(
+    await page.evaluate(() => localStorage.getItem('knote-autosave-interval-v1')),
+    '2',
+    'edited interval must persist'
+  )
+  // close the menu, edit, and let the (now 2s) clock save on its own
+  await pm.click()
+  await page.keyboard.press('End')
+  await page.keyboard.type(' INTERVAL_EDIT')
+  await page.getByTestId('unsaved-changes-badge').waitFor({ state: 'visible', timeout: 5_000 })
+  // 8s < the old 10s default: only the edited 2s interval can save in time
+  await waitUntil(() => fs.readFileSync(keepPath, 'utf8').includes('INTERVAL_EDIT'), {
+    timeout: 8_000,
+    message: 'clock did not follow the edited interval'
+  })
+})

--- a/scripts/source-editing.adversarial.test.mjs
+++ b/scripts/source-editing.adversarial.test.mjs
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   computeBackspaceUnwrap,
+  computeCodeAutoPair,
+  computeCodeEnterIndent,
+  computeCodeTab,
   computeEnterContinuation,
   computeSelectionSurround,
   countFenceLinesBefore,
@@ -201,3 +204,213 @@ test('non-wrap characters are ignored', () => {
 })
 
 const PAIR_CLOSE = { '(': ')', '[': ']', '{': '}' }
+
+// ---- code-fence smart editing -------------------------------------------
+
+const CODE_CLOSE = { '(': ')', '[': ']', '{': '}', '"': '"', "'": "'" }
+// A one-line fence body for caret math: line 2 is `body`.
+const inFence = (body) => '```\n' + body + '\n```\n'
+const after = (doc, frag) => doc.indexOf(frag) + frag.length
+
+// auto-pairing inside the fence -------------------------------------------
+
+test('code fence: ( [ { auto-close with the caret in the middle', () => {
+  for (const open of ['(', '[', '{']) {
+    const doc = inFence('a b')
+    const caret = after(doc, 'a') // right after a, before the space
+    const r = computeCodeAutoPair(doc, caret, caret, open)
+    assert.equal(r.value, inFence('a' + open + CODE_CLOSE[open] + ' b'))
+    assert.equal(r.selectionStart, caret + 1)
+    assert.equal(r.selectionEnd, caret + 1)
+  }
+})
+
+test('code fence: < stays literal (less-than is far more common than a tag)', () => {
+  const doc = inFence('a b')
+  const caret = after(doc, 'a')
+  assert.equal(computeCodeAutoPair(doc, caret, caret, '<'), null)
+})
+
+test('code fence: quotes auto-close (unlike plain text)', () => {
+  for (const q of ['"', "'"]) {
+    const doc = inFence('ab')
+    const caret = after(doc, 'a')
+    const r = computeCodeAutoPair(doc, caret, caret, q)
+    assert.equal(r.value, inFence('a' + q + q + 'b'))
+    assert.equal(r.selectionStart, caret + 1)
+  }
+})
+
+test('code fence: typing a close char overtypes an existing close at the caret', () => {
+  const doc = inFence('"ab"')
+  const caret = after(doc, 'b') // right before the closing quote
+  const r = computeCodeAutoPair(doc, caret, caret, '"')
+  assert.equal(r.value, doc) // nothing duplicated
+  assert.equal(r.selectionStart, caret + 1)
+  // same for a bracket: `f(a|)` typing `)` steps past it
+  const doc2 = inFence('f(a)')
+  const caret2 = after(doc2, 'a')
+  const r2 = computeCodeAutoPair(doc2, caret2, caret2, ')')
+  assert.equal(r2.value, doc2)
+  assert.equal(r2.selectionStart, caret2 + 1)
+})
+
+test('code fence: open char next to a close still inserts a fresh pair', () => {
+  const doc = inFence('f(a)')
+  const caret = after(doc, 'f') // between f and (a)
+  const r = computeCodeAutoPair(doc, caret, caret, '(')
+  assert.equal(r.value, inFence('f()(a)'))
+  assert.equal(r.selectionStart, caret + 1)
+  assert.equal(r.selectionEnd, caret + 1)
+})
+
+test('code fence: wrap and toggle a selection with a pair char', () => {
+  const doc = inFence('word')
+  const from = doc.indexOf('word')
+  const to = after(doc, 'word')
+  const r = computeCodeAutoPair(doc, from, to, '[')
+  assert.equal(r.value, inFence('[word]'))
+  assert.equal(r.selectionStart, from + 1)
+  assert.equal(r.selectionEnd, to + 1)
+  // second trigger on the wrapped selection unwraps it again
+  const wrappedFrom = r.value.indexOf('[') + 1
+  const wrappedTo = after(r.value, 'word') // right where the closing ] sits
+  const off = computeCodeAutoPair(r.value, wrappedFrom, wrappedTo, '[')
+  assert.equal(off.value, doc)
+})
+
+test('code fence: mirror chars and non-pair chars stay literal', () => {
+  for (const ch of ['*', '_', '~', '`', 'q']) {
+    const doc = inFence('ab')
+    const caret = after(doc, 'a')
+    assert.equal(computeCodeAutoPair(doc, caret, caret, ch), null)
+  }
+})
+
+test('code fence helpers are inert outside fences', () => {
+  assert.equal(computeCodeAutoPair('a b', 1, 1, '('), null)
+  assert.equal(computeCodeEnterIndent('  a', 3), null)
+  assert.equal(computeCodeTab('a b', 1, 1), null)
+  assert.equal(computeCodeTab('a\nb', 0, 3), null)
+})
+
+// Enter auto-indent inside the fence --------------------------------------
+
+test('code fence: Enter keeps the current indentation', () => {
+  const doc = inFence('    x')
+  const caret = after(doc, 'x')
+  const r = computeCodeEnterIndent(doc, caret)
+  assert.equal(r.value, inFence('    x\n    '))
+  assert.equal(r.selectionStart, caret + 5)
+})
+
+test('code fence: Enter inside unclosed brackets indents one extra level', () => {
+  const doc = inFence('foo(')
+  const caret = after(doc, 'foo(')
+  const r = computeCodeEnterIndent(doc, caret)
+  assert.equal(r.value, inFence('foo(\n    '))
+  const doc2 = inFence('if (a) {')
+  const r2 = computeCodeEnterIndent(doc2, after(doc2, 'if (a) {'))
+  assert.equal(r2.value, inFence('if (a) {\n    '))
+})
+
+test('code fence: Enter inside an empty pair pushes the closer onto its own line', () => {
+  const doc = inFence('int main() {}')
+  const caret = after(doc, '{')
+  const r = computeCodeEnterIndent(doc, caret)
+  assert.equal(r.value, inFence('int main() {\n    \n}'))
+  assert.equal(r.selectionStart, caret + 5) // newline + one 4-space level
+  // same for brackets/quotes of a paren group
+  const doc2 = inFence('fn()')
+  const r2 = computeCodeEnterIndent(doc2, after(doc2, '('))
+  assert.equal(r2.value, inFence('fn(\n    \n)'))
+  // a nested (indented) opener keeps the closer at the opener indent
+  const doc3 = inFence('  call() {}')
+  const r3 = computeCodeEnterIndent(doc3, after(doc3, '{'))
+  assert.equal(r3.value, inFence('  call() {\n      \n  }'))
+})
+
+test('code fence: Enter does not split a pair that already has content', () => {
+  const doc = inFence('fn(a)')
+  const r = computeCodeEnterIndent(doc, after(doc, '('))
+  // typed ends inside unclosed ( → one extra level, but `a)` stays in place
+  assert.equal(r.value, inFence('fn(\n    a)'))
+})
+
+test('code fence: Enter on a line with no indent adds a plain newline', () => {
+  const doc = inFence('plain')
+  const r = computeCodeEnterIndent(doc, after(doc, 'plain'))
+  assert.equal(r.value, inFence('plain\n'))
+})
+
+test('code fence: brackets inside string literals do not deepen the indent', () => {
+  const doc = inFence('s = "not (closed"')
+  const r = computeCodeEnterIndent(doc, after(doc, 's = "not (closed"'))
+  assert.equal(r.value, inFence('s = "not (closed"\n'))
+})
+
+test('code fence: Enter mid-line splits and carries the line indent', () => {
+  const doc = inFence('    ab')
+  const caret = after(doc, 'a')
+  const r = computeCodeEnterIndent(doc, caret)
+  assert.equal(r.value, inFence('    a\n    b'))
+  assert.equal(r.selectionStart, caret + 5)
+})
+
+test('code fence: Enter while inside the leading whitespace keeps it', () => {
+  const doc = inFence('    x')
+  const caret = after(doc, '  ') // inside the 4-space indent, after 2 spaces
+  const r = computeCodeEnterIndent(doc, caret)
+  // only the whitespace before the caret carries over; the rest of the line
+  // (2 spaces + x) stays put
+  assert.equal(r.value, inFence('  \n    x'))
+})
+
+// Tab inside the fence -----------------------------------------------------
+
+test('code fence: Tab inserts one 4-space indent level at the caret', () => {
+  const doc = inFence('x')
+  const caret = after(doc, 'x')
+  const r = computeCodeTab(doc, caret, caret)
+  assert.equal(r.value, inFence('x    '))
+  assert.equal(r.selectionStart, caret + 4)
+})
+
+test('code fence: Tab completes a partial indent to the next tab stop', () => {
+  // three spaces already there → Tab adds just one more to reach four
+  const doc3 = inFence('   x')
+  const r3 = computeCodeTab(doc3, doc3.indexOf('x'), doc3.indexOf('x'))
+  assert.equal(r3.value, inFence('    x'))
+  assert.equal(r3.selectionStart, r3.value.indexOf('x'))
+  // five spaces (one level + one extra space) → Tab adds three
+  const doc5 = inFence('     x')
+  const r5 = computeCodeTab(doc5, doc5.indexOf('x'), doc5.indexOf('x'))
+  assert.equal(r5.value, inFence('        x'))
+})
+
+test('code fence: Tab follows the line indent style (tab lines get tabs)', () => {
+  const doc = '```\n\tx\n```\n'
+  const caret = after(doc, 'x')
+  const r = computeCodeTab(doc, caret, caret)
+  assert.equal(r.value, '```\n\tx\t\n```\n')
+})
+
+test('code fence: Tab with a multi-line selection indents each line', () => {
+  const doc = '```\na\nb\nc\n```\n'
+  const from = after(doc, 'a') - 1 // start of line a
+  const to = after(doc, 'b') // right after b (b's newline follows)
+  const r = computeCodeTab(doc, from, to)
+  assert.equal(r.value, '```\n    a\n    b\nc\n```\n')
+  assert.equal(r.selectionStart, from + 4)
+  assert.equal(r.selectionEnd, to + 8) // two lines indented, 4 chars each
+})
+
+test('code fence: Tab skips empty lines inside the selection', () => {
+  const doc = '```\na\n\nc\n```\n'
+  const from = after(doc, 'a') - 1
+  const to = after(doc, 'c')
+  const r = computeCodeTab(doc, from, to)
+  assert.equal(r.value, '```\n    a\n\n    c\n```\n')
+  assert.equal(r.selectionStart, from + 4)
+  assert.equal(r.selectionEnd, to + 8)
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,7 @@ import { AGENT_CAPABILITY_KEYS, classifyAgentCapabilities } from './lib/agentCap
 import { collectImageResourcePaths, decodeRelativeResourcePath, rewriteImageResourcePaths } from './lib/imagePathMapping.js'
 import { analyzeDocumentChunked, filterOutlineItemsForSidebar } from './lib/documentMetrics.js'
 import { applyLargeSourcePageDraft, applyZeroWidthDeletion, buildLargeSourceOffsets, estimateLargeSourceDraftCaret, findLargeSourcePageByOffset, readLargeSourcePage, rebalanceLargeSourceView } from './lib/largeSourceDraft.js'
-import { computeBackspaceUnwrap, computeEnterContinuation, computeSelectionSurround } from './lib/sourceEditing.js'
+import { computeBackspaceUnwrap, computeCodeAutoPair, computeCodeEnterIndent, computeCodeTab, computeEnterContinuation, computeSelectionSurround, isInsideCodeFence } from './lib/sourceEditing.js'
 import { shouldUsePagedSource, LARGE_SOURCE_CHUNK_SIZE } from './lib/largeDocumentPolicy.js'
 import { selectTabsToOffload } from './lib/tabResidencyPolicy.js'
 import { renderMermaidIn } from './lib/mermaidRender.js'
@@ -849,7 +849,7 @@ const translations = {
     hw_accel_restart: '硬件加速设置将在重启后生效。现在重启应用吗？',
     hw_accel_failed: '设置保存失败，请重试',
     source_smart_edit: '源码智能编辑',
-    source_smart_edit_hint: '源码模式下自动续列表/引用、选中包裹（默认关闭）',
+    source_smart_edit_hint: '源码智能编辑：续列表/引用、选中包裹；代码块内自动补括号引号、Tab 与回车智能缩进（默认关闭）',
     split_scroll_sync: '分栏滚动同步',
     split_scroll_sync_hint: '两侧按滚动比例联动，保持浏览同一位置',
     split_selection_follow: '选区联动预览',
@@ -1331,7 +1331,7 @@ const translations = {
     hw_accel_restart: 'The hardware acceleration setting applies after a restart. Restart now?',
     hw_accel_failed: 'Could not save the setting, please retry',
     source_smart_edit: 'Source smart editing',
-    source_smart_edit_hint: 'Auto-continue lists/quotes and surround selections in source mode (off by default)',
+    source_smart_edit_hint: 'Smart editing in source mode: continue lists/quotes, surround selections; auto-pair brackets & quotes, Tab/Enter smart indent inside code fences (off by default)',
     split_scroll_sync: 'Sync split scrolling',
     split_scroll_sync_hint: 'Keep both panes at the same scroll position',
     split_selection_follow: 'Preview follows selection',
@@ -12510,6 +12510,9 @@ const hideToolbar = (event) => {
 // Handle keydown in split-view textarea: skip over ZWS (\u200B) on Backspace/Delete,
 // then (opt-in source smart editing) continue list/quote prefixes on Enter,
 // unwrap empty list items on Backspace, and surround the selection on wrap chars.
+// Inside a code fence the plain-text rules stay off and an IDE-like subset
+// applies instead: auto-paired brackets/quotes, Tab indentation and Enter that
+// keeps (or inside brackets, deepens) the indentation.
 const handleTextareaKeydown = (e) => {
   const el = e.target
   const pos = el.selectionStart
@@ -12523,13 +12526,17 @@ const handleTextareaKeydown = (e) => {
     return
   }
   if (!sourceSmartEdit.value || e.isComposing || e.keyCode === 229) return
+  const lineStart = val.lastIndexOf('\n', pos - 1) + 1
+  const isFence = isInsideCodeFence(val, lineStart)
   let edit = null
   if (e.key === 'Enter') {
-    edit = computeEnterContinuation(val, pos)
+    edit = isFence ? computeCodeEnterIndent(val, pos) : computeEnterContinuation(val, pos)
+  } else if (e.key === 'Tab') {
+    if (isFence) edit = computeCodeTab(val, pos, end)
   } else if (e.key === 'Backspace') {
     edit = computeBackspaceUnwrap(val, pos)
   } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
-    edit = computeSelectionSurround(val, pos, end, e.key)
+    edit = isFence ? computeCodeAutoPair(val, pos, end, e.key) : computeSelectionSurround(val, pos, end, e.key)
   }
   if (!edit) return
   e.preventDefault()

--- a/src/App.vue
+++ b/src/App.vue
@@ -850,6 +850,8 @@ const translations = {
     hw_accel_failed: '设置保存失败，请重试',
     source_smart_edit: '源码智能编辑',
     source_smart_edit_hint: '源码智能编辑：续列表/引用、选中包裹；代码块内自动补括号引号、Tab 与回车智能缩进（默认关闭）',
+    floating_sidebar_side: '浮动侧边栏靠右',
+    floating_sidebar_side_hint: '分栏模式的悬浮侧边栏默认从左侧弹出；开启后从右侧对称弹出',
     split_scroll_sync: '分栏滚动同步',
     split_scroll_sync_hint: '两侧按滚动比例联动，保持浏览同一位置',
     split_selection_follow: '选区联动预览',
@@ -1332,6 +1334,8 @@ const translations = {
     hw_accel_failed: 'Could not save the setting, please retry',
     source_smart_edit: 'Source smart editing',
     source_smart_edit_hint: 'Smart editing in source mode: continue lists/quotes, surround selections; auto-pair brackets & quotes, Tab/Enter smart indent inside code fences (off by default)',
+    floating_sidebar_side: 'Float split sidebar on the right',
+    floating_sidebar_side_hint: 'The split-mode floating sidebar slides in from the left by default; enable to mirror it to the right edge',
     split_scroll_sync: 'Sync split scrolling',
     split_scroll_sync_hint: 'Keep both panes at the same scroll position',
     split_selection_follow: 'Preview follows selection',
@@ -9127,8 +9131,18 @@ const openMobileAgent = () => {
 
 // ========== Floating split-mode sidebar ==========
 // Split view hides the left sidebar to keep both columns wide. Hovering the
-// right edge slides the outline + file tree in as an overlay (it never
+// screen edge slides the outline + file tree in as an overlay (it never
 // reflows the two columns); leaving the panel/edge slides it back out.
+// The edge can sit on the left (author default) or — via the menu setting —
+// be mirrored to the right; both variants are fully symmetric.
+const FLOATING_SIDEBAR_RIGHT_KEY = 'knote-floating-sidebar-right-v1'
+const floatingSidebarRight = ref((() => {
+  try { return localStorage.getItem(FLOATING_SIDEBAR_RIGHT_KEY) === '1' } catch { return false }
+})())
+const toggleFloatingSidebarRight = () => {
+  floatingSidebarRight.value = !floatingSidebarRight.value
+  try { localStorage.setItem(FLOATING_SIDEBAR_RIGHT_KEY, floatingSidebarRight.value ? '1' : '0') } catch { /* best-effort */ }
+}
 const floatingSidebarOpen = ref(false)
 let floatingSidebarHideTimer = null
 const floatingSidebarShow = () => {
@@ -14200,6 +14214,20 @@ onBeforeUnmount(() => {
                     <svg v-if="sourceSmartEdit" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
                   </a>
                 </li>
+                <li v-if="!isAndroidNative">
+                  <a
+                    data-testid="floating-sidebar-side-toggle"
+                    class="flex items-center gap-2"
+                    role="menuitemcheckbox"
+                    :aria-checked="floatingSidebarRight"
+                    :title="t('floating_sidebar_side_hint')"
+                    @click="toggleFloatingSidebarRight"
+                  >
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/><path d="M15 21V3"/></svg>
+                    <span class="flex-1">{{ t('floating_sidebar_side') }}</span>
+                    <svg v-if="floatingSidebarRight" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
+                  </a>
+                </li>
 <li data-testid="open-history" @click="openHistory(); blurActiveElement()">
                     <a class="flex items-center gap-2">
                         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 2m6-2a9 9 0 1 1-3.5-7.1M21 3v5h-5"/></svg>
@@ -15537,21 +15565,23 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <!-- Floating split-mode sidebar: hover the left edge to slide the
-         outline + file tree in as an overlay (never reflows the split
-         columns); leaving panel or edge slides it back out. -->
+    <!-- Floating split-mode sidebar: hover the screen edge (left by default,
+         right when the 靠右 setting is on) to slide the outline + file tree
+         in as an overlay (never reflows the split columns); leaving panel or
+         edge slides it back out. -->
     <template v-if="viewMode === 'split' && !pdfView && !largeDocumentPlainMode">
       <div
-        class="knote-floating-edge hidden lg:block fixed left-0 top-0 h-full w-2.5 z-[1050] print:hidden"
-        :class="{ 'is-open': floatingSidebarOpen }"
+        class="knote-floating-edge hidden lg:block fixed top-0 h-full w-2.5 z-[1050] print:hidden"
+        :class="[floatingSidebarRight ? 'right-0' : 'left-0', floatingSidebarRight ? 'side-right' : 'side-left', { 'is-open': floatingSidebarOpen }]"
         aria-hidden="true"
         @mouseenter="floatingSidebarShow"
         @mouseleave="floatingSidebarHide"
       ><span class="knote-floating-grip"></span></div>
-      <Transition name="kfloating">
+      <Transition :name="floatingSidebarRight ? 'kfloating-r' : 'kfloating'">
         <div
           v-if="floatingSidebarOpen"
-          class="knote-floating-sidebar hidden lg:block fixed left-0 top-[7rem] w-[330px] z-[1050] print:hidden"
+          class="knote-floating-sidebar hidden lg:block fixed top-[7rem] w-[330px] z-[1050] print:hidden"
+          :class="[floatingSidebarRight ? 'right-0' : 'left-0', floatingSidebarRight ? 'side-right' : 'side-left']"
           @mouseenter="floatingSidebarCancelHide"
           @mouseleave="floatingSidebarHide"
         >
@@ -15851,6 +15881,13 @@ onBeforeUnmount(() => {
                 <svg v-if="sourceSmartEdit" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
               </a>
             </li>
+            <li v-if="!isAndroidNative">
+              <a data-testid="floating-sidebar-side-float" class="flex items-center gap-2 text-xs py-1" role="menuitemcheckbox" :aria-checked="floatingSidebarRight" :title="t('floating_sidebar_side_hint')" @click="toggleFloatingSidebarRight">
+                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/><path d="M15 21V3"/></svg>
+                <span class="flex-1">{{ t('floating_sidebar_side') }}</span>
+                <svg v-if="floatingSidebarRight" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
+              </a>
+            </li>
             <li><a class="flex items-center gap-2 text-xs py-1" @click="openHistory(); closeFloatingMenu()"><svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 2m6-2a9 9 0 1 1-3.5-7.1M21 3v5h-5"/></svg>{{ t('history') }}</a></li>
             <li><a class="flex items-center gap-2 text-xs py-1" @click="loadSample('zh'); closeFloatingMenu()"><svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="m9.5 16 1.3-2.7L13.5 12l-2.7-1.3L9.5 8l-1.3 2.7L5.5 12l2.7 1.3z"/></svg>{{ t('load_sample_zh') }}</a></li>
             <li><a class="flex items-center gap-2 text-xs py-1" @click="loadSample('en'); closeFloatingMenu()"><svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="m9.5 16 1.3-2.7L13.5 12l-2.7-1.3L9.5 8l-1.3 2.7L5.5 12l2.7 1.3z"/></svg>{{ t('load_sample_en') }}</a></li>
@@ -15951,6 +15988,43 @@ onBeforeUnmount(() => {
    when they overflow, the panel scrolls as a whole. */
 .knote-floating-sidebar-inner > * {
   flex: none;
+}
+/* ---- Mirrored right-edge variant ---- */
+/* When the 靠右 setting is on the Tailwind right-0/left-0 utilities place the
+   edge and panel; these rules flip every visual authored for the left edge so
+   the right side is fully symmetric (grip tab, chevron, radii, border side,
+   shadows and the slide-in direction). */
+.knote-floating-edge.side-right .knote-floating-grip {
+  left: auto;
+  right: 0;
+  border-radius: 12px 0 0 12px;
+  border-left: 1px solid var(--color-base-200);
+  border-right: none;
+  box-shadow: -6px 0 16px rgb(0 0 0 / 0.10);
+}
+.knote-floating-edge.side-right:hover .knote-floating-grip {
+  box-shadow: -6px 0 18px rgb(132 204 22 / 0.35);
+}
+.knote-floating-edge.side-right .knote-floating-grip::before {
+  /* the "›" affordance points where the panel slides in; mirror it to "‹" */
+  transform: rotate(225deg);
+}
+.knote-floating-edge.side-right.is-open .knote-floating-grip {
+  transform: translateX(9px);
+}
+.knote-floating-sidebar.side-right .knote-floating-sidebar-inner {
+  border-right: none;
+  border-left: 1px solid var(--color-base-200);
+  border-radius: 0.75rem 0 0 0.75rem;
+  box-shadow: -8px 0 24px rgb(0 0 0 / 0.08);
+}
+.kfloating-r-enter-active,
+.kfloating-r-leave-active {
+  transition: transform 0.2s ease-out;
+}
+.kfloating-r-enter-from,
+.kfloating-r-leave-to {
+  transform: translateX(100%);
 }
 .knote-agent-review-bar {
   border-color: color-mix(in srgb, var(--knote-brand) 24%, transparent);

--- a/src/App.vue
+++ b/src/App.vue
@@ -852,6 +852,11 @@ const translations = {
     source_smart_edit_hint: '源码智能编辑：续列表/引用、选中包裹；代码块内自动补括号引号、Tab 与回车智能缩进（默认关闭）',
     floating_sidebar_side: '浮动侧边栏靠右',
     floating_sidebar_side_hint: '分栏模式的悬浮侧边栏默认从左侧弹出；开启后从右侧对称弹出',
+    autosave: '自动保存',
+    autosave_hint: '按固定间隔自动保存当前文件（直接走 Ctrl+S 的保存逻辑，不抢快捷键、无感；默认关闭）',
+    autosave_interval: '自动保存间隔',
+    autosave_interval_hint: '多久检查一次当前文件，有未保存更改则自动保存（秒）',
+    unsaved_changes: '有未保存更改',
     split_scroll_sync: '分栏滚动同步',
     split_scroll_sync_hint: '两侧按滚动比例联动，保持浏览同一位置',
     split_selection_follow: '选区联动预览',
@@ -1336,6 +1341,11 @@ const translations = {
     source_smart_edit_hint: 'Smart editing in source mode: continue lists/quotes, surround selections; auto-pair brackets & quotes, Tab/Enter smart indent inside code fences (off by default)',
     floating_sidebar_side: 'Float split sidebar on the right',
     floating_sidebar_side_hint: 'The split-mode floating sidebar slides in from the left by default; enable to mirror it to the right edge',
+    autosave: 'Auto-save',
+    autosave_hint: 'Automatically save the current file at a fixed interval (runs the same save path as Ctrl+S — no synthetic keypress, fully silent; off by default)',
+    autosave_interval: 'Auto-save interval',
+    autosave_interval_hint: 'How often to check the current file and save it when it has unsaved changes (seconds)',
+    unsaved_changes: 'Unsaved changes',
     split_scroll_sync: 'Sync split scrolling',
     split_scroll_sync_hint: 'Keep both panes at the same scroll position',
     split_selection_follow: 'Preview follows selection',
@@ -5338,6 +5348,61 @@ const saveFile = async () => {
 // Auto-save watcher: debounce writes to local file
 let autoSaveDirty = false
 let autoSaveJob = null
+// ===== Optional timed auto-save (opt-in via the menu, default OFF) =====
+// The previous always-on "save one second after every edit" debounce is gone:
+// saving is manual again unless the user turns 自动保存 on. When on, a fixed
+// interval clock checks the CURRENT file; if it is ahead of disk it calls the
+// same saveFile() that Ctrl+S invokes — never a synthetic key event, so the
+// user feels nothing (no focus steal, no save dialog for unbacked files).
+const AUTOSAVE_ENABLED_KEY = 'knote-autosave-enabled-v1'
+const AUTOSAVE_INTERVAL_KEY = 'knote-autosave-interval-v1'
+const autoSaveOn = ref((() => {
+  try { return localStorage.getItem(AUTOSAVE_ENABLED_KEY) === '1' } catch { return false }
+})())
+const autoSaveIntervalSeconds = ref((() => {
+  try {
+    const v = parseInt(localStorage.getItem(AUTOSAVE_INTERVAL_KEY) || '10', 10)
+    return Number.isFinite(v) && v >= 1 ? v : 30
+  } catch { return 30 }
+})())
+const toggleAutoSave = () => {
+  autoSaveOn.value = !autoSaveOn.value
+  try { localStorage.setItem(AUTOSAVE_ENABLED_KEY, autoSaveOn.value ? '1' : '0') } catch { /* best-effort */ }
+}
+const setAutoSaveInterval = (value) => {
+  const v = Math.round(Number(value))
+  if (!Number.isFinite(v)) return
+  const clamped = Math.min(3600, Math.max(1, v))
+  autoSaveIntervalSeconds.value = clamped
+  try { localStorage.setItem(AUTOSAVE_INTERVAL_KEY, String(clamped)) } catch { /* best-effort */ }
+}
+const autoSaveClock = async () => {
+  if (!autoSaveOn.value) return
+  if (document.hidden) return // never write while minimized/backgrounded
+  if (!isLocalFile.value || !currentFileHandle.value) return // would pop a picker
+  if (isSaving.value) return
+  if (!documentIsAheadOfDisk(snapshotDocKey())) return
+  await saveFile()
+}
+let autoSaveClockTimer = null
+const restartAutoSaveClock = () => {
+  if (autoSaveClockTimer) {
+    clearInterval(autoSaveClockTimer)
+    autoSaveClockTimer = null
+  }
+  if (!autoSaveOn.value) return
+  autoSaveClockTimer = setInterval(() => { autoSaveClock() }, Math.max(1000, autoSaveIntervalSeconds.value * 1000))
+}
+watch(autoSaveOn, restartAutoSaveClock)
+watch(autoSaveIntervalSeconds, restartAutoSaveClock)
+restartAutoSaveClock() // pick up a previously enabled session
+
+// Live unsaved check for the navbar status pill. The edit/saved revision maps
+// are plain Maps (not reactive), so this is a function evaluated on render —
+// any content change re-renders and yields the fresh answer.
+const currentFileHasUnsavedChanges = () =>
+  isLocalFile.value && documentIsAheadOfDisk(snapshotDocKey())
+
 // tab switches swap `content` wholesale — that's navigation, not an edit:
 // no undo snapshot, no autosave marking
 // A monotonic owner token makes the navigation-install guard race-safe. A
@@ -5356,36 +5421,15 @@ const finishNavigationInstall = (owner) => {
 watch(() => content.value, () => {
   if (navigationInstallOwner) return
   const editIdentity = snapshotDocKey()
-  const editRevision = markDocumentEdited(editIdentity)
+  markDocumentEdited(editIdentity)
   // Track undo (skipped during undo/redo transitions)
   // ProseMirror already owns single-mode history. Mirroring another 50 full
   // Markdown snapshots here multiplied long-document memory for no benefit.
   if (viewMode.value !== 'single' || largeDocumentPlainMode.value) scheduleUndoSnapshot()
-
-  // Auto-save to local file. Undo/redo results must also reach the disk —
-  // otherwise the file keeps the undone content forever.
-  if (isLocalFile.value && currentFileHandle.value) {
-    // Freeze the handle, markdown and history key together. The timeout must
-    // never consult live refs because navigation may replace them first.
-    const job = {
-      handle: currentFileHandle.value,
-      payload: {
-        markdown: exportableMarkdown(content.value),
-        snapshotContent: content.value,
-        snapshotKey: editIdentity,
-        revision: editRevision
-      }
-    }
-    autoSaveJob = job
-    autoSaveDirty = true
-    clearTimeout(autoSaveTimer)
-    autoSaveTimer = setTimeout(() => {
-      if (autoSaveJob !== job) return
-      autoSaveDirty = false
-      autoSaveJob = null
-      saveToFileHandle(job.handle, job.payload)
-    }, 1000)
-  }
+  // Disk writes are NOT scheduled here anymore: with 自动保存 on, the fixed
+  // interval clock (autoSaveClock) above owns them; with it off, saving is
+  // manual (Ctrl+S / save button) and the unsaved-changes lamp reminds the
+  // user. The dirty flag stays exact via documentIsAheadOfDisk.
 }, { flush: 'sync' })
 
 // Moving the caret to another row is a natural commit point: flush the
@@ -13966,8 +14010,19 @@ onBeforeUnmount(() => {
             : 'bg-warning/10 text-warning'"
         >
           <template v-if="isLocalFile">
-            <span class="w-2 h-2 rounded-full bg-success"></span>
-            <span data-testid="current-file-name" class="max-w-[200px] truncate">{{ currentFileName }}</span>
+            <!-- The lamp reflects the REAL save state: green once the file is
+                 on disk; any later edit turns it amber with a hint until the
+                 user saves (or 自动保存's clock writes it) again. -->
+            <span
+              class="w-2 h-2 rounded-full"
+              :class="currentFileHasUnsavedChanges() ? 'bg-warning' : 'bg-success'"
+            ></span>
+            <template v-if="currentFileHasUnsavedChanges()">
+              <span data-testid="unsaved-changes-badge" class="max-w-[220px] truncate text-warning">{{ t('unsaved_changes') }}</span>
+            </template>
+            <template v-else>
+              <span data-testid="current-file-name" class="max-w-[200px] truncate">{{ currentFileName }}</span>
+            </template>
             <span v-if="isSaving" class="loading loading-spinner loading-xs opacity-50"></span>
           </template>
           <template v-else>
@@ -14060,6 +14115,21 @@ onBeforeUnmount(() => {
               </li>
             </template>
           </ul>
+        </div>
+
+        <!-- Auto-save status lamp: lit while 自动保存 is on; blinks on the
+             clock so a glance shows the feature is actively watching. -->
+        <div
+          v-if="autoSaveOn"
+          data-testid="autosave-indicator"
+          class="knote-autosave-indicator flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-[#65a30d] mr-0.5 tooltip tooltip-bottom"
+          :data-tip="t('autosave') + ' · ' + autoSaveIntervalSeconds + 's'"
+        >
+          <span class="relative flex w-2 h-2">
+            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-[#84cc16] opacity-60"></span>
+            <span class="relative inline-flex rounded-full w-2 h-2 bg-[#84cc16]"></span>
+          </span>
+          <span class="hidden sm:inline">AUTO</span>
         </div>
 
         <!-- Save -->
@@ -14228,7 +14298,40 @@ onBeforeUnmount(() => {
                     <svg v-if="floatingSidebarRight" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
                   </a>
                 </li>
-<li data-testid="open-history" @click="openHistory(); blurActiveElement()">
+                <li v-if="!isAndroidNative">
+                  <a
+                    data-testid="autosave-toggle"
+                    class="flex items-center gap-2"
+                    role="menuitemcheckbox"
+                    :aria-checked="autoSaveOn"
+                    :title="t('autosave_hint')"
+                    @click="toggleAutoSave"
+                  >
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+                    <span class="flex-1">{{ t('autosave') }}</span>
+                    <svg v-if="autoSaveOn" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
+                  </a>
+                </li>
+                <li v-if="!isAndroidNative && autoSaveOn">
+                  <div class="flex items-center gap-2 py-1.5 pl-1">
+                    <span class="flex-1 whitespace-nowrap text-sm">{{ t('autosave_interval') }}</span>
+                    <input
+                      data-testid="autosave-interval-input"
+                      class="input input-xs input-bordered w-16 text-right tabular-nums"
+                      type="number"
+                      min="5"
+                      max="3600"
+                      step="1"
+                      :value="autoSaveIntervalSeconds"
+                      :title="t('autosave_interval_hint')"
+                      @click.stop
+                      @keydown.stop
+                      @input="setAutoSaveInterval($event.target.value)"
+                    />
+                    <span class="text-xs opacity-60">s</span>
+                  </div>
+                </li>
+                <li data-testid="open-history" @click="openHistory(); blurActiveElement()">
                     <a class="flex items-center gap-2">
                         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 2m6-2a9 9 0 1 1-3.5-7.1M21 3v5h-5"/></svg>
                         {{ t('history') }}
@@ -15887,6 +15990,32 @@ onBeforeUnmount(() => {
                 <span class="flex-1">{{ t('floating_sidebar_side') }}</span>
                 <svg v-if="floatingSidebarRight" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
               </a>
+            </li>
+            <li v-if="!isAndroidNative">
+              <a data-testid="floating-autosave-toggle" class="flex items-center gap-2 text-xs py-1" role="menuitemcheckbox" :aria-checked="autoSaveOn" :title="t('autosave_hint')" @click="toggleAutoSave">
+                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+                <span class="flex-1">{{ t('autosave') }}</span>
+                <svg v-if="autoSaveOn" class="w-3.5 h-3.5 text-[#65a30d]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 4 4L19 6"/></svg>
+              </a>
+            </li>
+            <li v-if="!isAndroidNative && autoSaveOn">
+              <div class="flex items-center gap-2 py-1 pl-1">
+                <span class="flex-1 whitespace-nowrap">{{ t('autosave_interval') }}</span>
+                <input
+                  data-testid="floating-autosave-interval-input"
+                  class="input input-xs input-bordered w-16 text-right tabular-nums"
+                  type="number"
+                  min="5"
+                  max="3600"
+                  step="1"
+                  :value="autoSaveIntervalSeconds"
+                  :title="t('autosave_interval_hint')"
+                  @click.stop
+                  @keydown.stop
+                  @input="setAutoSaveInterval($event.target.value)"
+                />
+                <span class="text-xs opacity-60">s</span>
+              </div>
             </li>
             <li><a class="flex items-center gap-2 text-xs py-1" @click="openHistory(); closeFloatingMenu()"><svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 2m6-2a9 9 0 1 1-3.5-7.1M21 3v5h-5"/></svg>{{ t('history') }}</a></li>
             <li><a class="flex items-center gap-2 text-xs py-1" @click="loadSample('zh'); closeFloatingMenu()"><svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="m9.5 16 1.3-2.7L13.5 12l-2.7-1.3L9.5 8l-1.3 2.7L5.5 12l2.7 1.3z"/></svg>{{ t('load_sample_zh') }}</a></li>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9183,9 +9183,35 @@ const FLOATING_SIDEBAR_RIGHT_KEY = 'knote-floating-sidebar-right-v1'
 const floatingSidebarRight = ref((() => {
   try { return localStorage.getItem(FLOATING_SIDEBAR_RIGHT_KEY) === '1' } catch { return false }
 })())
+// Flipping the side setting while the panel is open: retract the panel on ITS
+// own side first (the leave animation must still use the old direction), then
+// flip the edge once the slide-out finished — so the old panel never slides
+// the wrong way and the new edge is immediately ready to hover open.
+let floatingSidebarFlipTimer = null
+let floatingSidebarFlipPending = false
 const toggleFloatingSidebarRight = () => {
-  floatingSidebarRight.value = !floatingSidebarRight.value
-  try { localStorage.setItem(FLOATING_SIDEBAR_RIGHT_KEY, floatingSidebarRight.value ? '1' : '0') } catch { /* best-effort */ }
+  const next = !floatingSidebarRight.value
+  // Persist the choice immediately; only the visual edge flip waits for the
+  // panel to finish retracting (so the leave animation keeps the old side).
+  try { localStorage.setItem(FLOATING_SIDEBAR_RIGHT_KEY, next ? '1' : '0') } catch { /* best-effort */ }
+  // The toggle lives in menus: picking it dismisses the menu too, never a
+  // second click on empty space.
+  floatingMenu.value = null
+  if (floatingSidebarOpen.value) {
+    // Retract on the current side first, flip afterwards.
+    floatingSidebarOpen.value = false
+    if (floatingSidebarFlipTimer) clearTimeout(floatingSidebarFlipTimer)
+    floatingSidebarFlipPending = true
+    floatingSidebarFlipTimer = setTimeout(() => {
+      floatingSidebarFlipTimer = null
+      floatingSidebarFlipPending = false
+      floatingSidebarRight.value = next
+    }, 280) // panel leave transition is 0.2s
+  } else {
+    if (floatingSidebarFlipTimer) clearTimeout(floatingSidebarFlipTimer)
+    floatingSidebarFlipPending = false
+    floatingSidebarRight.value = next
+  }
 }
 const floatingSidebarOpen = ref(false)
 let floatingSidebarHideTimer = null
@@ -9194,6 +9220,7 @@ const floatingSidebarShow = () => {
     clearTimeout(floatingSidebarHideTimer)
     floatingSidebarHideTimer = null
   }
+  if (floatingSidebarFlipPending) return // mid-flip: wait for the new edge
   floatingSidebarOpen.value = true
 }
 const floatingSidebarCancelHide = () => {
@@ -9213,7 +9240,7 @@ const floatingSidebarHide = () => {
     floatingSidebarHideTimer = null
     floatingSidebarOpen.value = false
     floatingMenu.value = null
-  }, 250)
+  }, 150)
 }
 
 // Fixed-position popups for the floating/sidebar actions card: the panel's
@@ -9232,6 +9259,15 @@ const openFloatingMenu = (kind, event) => {
   floatingMenu.value = floatingMenu.value === kind ? null : kind
 }
 const closeFloatingMenu = () => { floatingMenu.value = null }
+// Clicking the popup backdrop dismisses the menu AND retracts the panel in
+// the same gesture. The plain closeFloatingMenu path is not enough there: the
+// panel hide is guarded while a menu is open, so without this the panel would
+// stay stranded until the pointer happens to revisit an edge.
+const dismissFloatingOverlay = () => {
+  floatingMenu.value = null
+  if (!floatingSidebarOpen.value) return
+  floatingSidebarHide()
+}
 
 // ========== Outline (document structure panel) ==========
 const outlineVisible = ref(true)
@@ -14291,7 +14327,7 @@ onBeforeUnmount(() => {
                     role="menuitemcheckbox"
                     :aria-checked="floatingSidebarRight"
                     :title="t('floating_sidebar_side_hint')"
-                    @click="toggleFloatingSidebarRight"
+                    @click="toggleFloatingSidebarRight(); blurActiveElement()"
                   >
                     <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/><path d="M15 21V3"/></svg>
                     <span class="flex-1">{{ t('floating_sidebar_side') }}</span>
@@ -15925,7 +15961,7 @@ onBeforeUnmount(() => {
       <div
         v-if="floatingMenu"
         class="fixed inset-0 z-[2000]"
-        @mousedown.self="closeFloatingMenu"
+        @mousedown.self="dismissFloatingOverlay"
       >
         <div
           class="absolute shadow-xl bg-base-100 rounded-box border border-base-200 menu p-1.5 min-w-[200px] w-max max-w-[min(24rem,85vw)] max-h-[70vh] overflow-y-auto flex-nowrap"

--- a/src/App.vue
+++ b/src/App.vue
@@ -853,9 +853,9 @@ const translations = {
     floating_sidebar_side: '浮动侧边栏靠右',
     floating_sidebar_side_hint: '分栏模式的悬浮侧边栏默认从左侧弹出；开启后从右侧对称弹出',
     autosave: '自动保存',
-    autosave_hint: '按固定间隔自动保存当前文件（直接走 Ctrl+S 的保存逻辑，不抢快捷键、无感；默认关闭）',
+    autosave_hint: '编辑停顿后自动保存到当前文件（默认开启，停顿 1 秒即保存；直接走 Ctrl+S 的保存逻辑，不抢快捷键、无感）',
     autosave_interval: '自动保存间隔',
-    autosave_interval_hint: '多久检查一次当前文件，有未保存更改则自动保存（秒）',
+    autosave_interval_hint: '停止编辑多久后自动保存（秒）',
     unsaved_changes: '有未保存更改',
     split_scroll_sync: '分栏滚动同步',
     split_scroll_sync_hint: '两侧按滚动比例联动，保持浏览同一位置',
@@ -1342,9 +1342,9 @@ const translations = {
     floating_sidebar_side: 'Float split sidebar on the right',
     floating_sidebar_side_hint: 'The split-mode floating sidebar slides in from the left by default; enable to mirror it to the right edge',
     autosave: 'Auto-save',
-    autosave_hint: 'Automatically save the current file at a fixed interval (runs the same save path as Ctrl+S — no synthetic keypress, fully silent; off by default)',
+    autosave_hint: 'Auto-save the current file after you pause typing (on by default — saves ~1s after an edit pause; runs the same save path as Ctrl+S, no synthetic keypress, fully silent)',
     autosave_interval: 'Auto-save interval',
-    autosave_interval_hint: 'How often to check the current file and save it when it has unsaved changes (seconds)',
+    autosave_interval_hint: 'How long after you stop editing before auto-saving (seconds)',
     unsaved_changes: 'Unsaved changes',
     split_scroll_sync: 'Sync split scrolling',
     split_scroll_sync_hint: 'Keep both panes at the same scroll position',
@@ -5348,22 +5348,24 @@ const saveFile = async () => {
 // Auto-save watcher: debounce writes to local file
 let autoSaveDirty = false
 let autoSaveJob = null
-// ===== Optional timed auto-save (opt-in via the menu, default OFF) =====
-// The previous always-on "save one second after every edit" debounce is gone:
-// saving is manual again unless the user turns 自动保存 on. When on, a fixed
-// interval clock checks the CURRENT file; if it is ahead of disk it calls the
-// same saveFile() that Ctrl+S invokes — never a synthetic key event, so the
-// user feels nothing (no focus steal, no save dialog for unbacked files).
+// ===== Auto-save (menu-tunable, ON by default with a 1s debounce) =====
+// This keeps the editor's original always-on behaviour — a short debounce
+// after every edit persists the file to disk — but the user can switch 自动保存
+// off (plain manual Ctrl+S mode) or change how long the debounce waits before
+// writing. The write goes through the same saveToFileHandle() the Ctrl+S path
+// uses — never a synthetic key event, so it stays fully silent (no focus
+// steal, no save dialog for unbacked files).
 const AUTOSAVE_ENABLED_KEY = 'knote-autosave-enabled-v1'
 const AUTOSAVE_INTERVAL_KEY = 'knote-autosave-interval-v1'
 const autoSaveOn = ref((() => {
-  try { return localStorage.getItem(AUTOSAVE_ENABLED_KEY) === '1' } catch { return false }
+  // Absent key = on: new users inherit the original always-on behaviour.
+  try { return localStorage.getItem(AUTOSAVE_ENABLED_KEY) !== '0' } catch { return true }
 })())
 const autoSaveIntervalSeconds = ref((() => {
   try {
-    const v = parseInt(localStorage.getItem(AUTOSAVE_INTERVAL_KEY) || '10', 10)
-    return Number.isFinite(v) && v >= 1 ? v : 30
-  } catch { return 30 }
+    const v = parseInt(localStorage.getItem(AUTOSAVE_INTERVAL_KEY) || '1', 10)
+    return Number.isFinite(v) && v >= 1 ? v : 1
+  } catch { return 1 }
 })())
 const toggleAutoSave = () => {
   autoSaveOn.value = !autoSaveOn.value
@@ -5376,26 +5378,7 @@ const setAutoSaveInterval = (value) => {
   autoSaveIntervalSeconds.value = clamped
   try { localStorage.setItem(AUTOSAVE_INTERVAL_KEY, String(clamped)) } catch { /* best-effort */ }
 }
-const autoSaveClock = async () => {
-  if (!autoSaveOn.value) return
-  if (document.hidden) return // never write while minimized/backgrounded
-  if (!isLocalFile.value || !currentFileHandle.value) return // would pop a picker
-  if (isSaving.value) return
-  if (!documentIsAheadOfDisk(snapshotDocKey())) return
-  await saveFile()
-}
-let autoSaveClockTimer = null
-const restartAutoSaveClock = () => {
-  if (autoSaveClockTimer) {
-    clearInterval(autoSaveClockTimer)
-    autoSaveClockTimer = null
-  }
-  if (!autoSaveOn.value) return
-  autoSaveClockTimer = setInterval(() => { autoSaveClock() }, Math.max(1000, autoSaveIntervalSeconds.value * 1000))
-}
-watch(autoSaveOn, restartAutoSaveClock)
-watch(autoSaveIntervalSeconds, restartAutoSaveClock)
-restartAutoSaveClock() // pick up a previously enabled session
+const autoSaveDebounceMs = () => Math.max(200, autoSaveIntervalSeconds.value * 1000)
 
 // Live unsaved check for the navbar status pill. The edit/saved revision maps
 // are plain Maps (not reactive), so this is a function evaluated on render —
@@ -5421,15 +5404,37 @@ const finishNavigationInstall = (owner) => {
 watch(() => content.value, () => {
   if (navigationInstallOwner) return
   const editIdentity = snapshotDocKey()
-  markDocumentEdited(editIdentity)
+  const editRevision = markDocumentEdited(editIdentity)
   // Track undo (skipped during undo/redo transitions)
   // ProseMirror already owns single-mode history. Mirroring another 50 full
   // Markdown snapshots here multiplied long-document memory for no benefit.
   if (viewMode.value !== 'single' || largeDocumentPlainMode.value) scheduleUndoSnapshot()
-  // Disk writes are NOT scheduled here anymore: with 自动保存 on, the fixed
-  // interval clock (autoSaveClock) above owns them; with it off, saving is
-  // manual (Ctrl+S / save button) and the unsaved-changes lamp reminds the
-  // user. The dirty flag stays exact via documentIsAheadOfDisk.
+
+  // Auto-save to local file (autoSaveOn gates it; the interval is the debounce
+  // length). Undo/redo results must also reach the disk — otherwise the file
+  // keeps the undone content forever.
+  if (autoSaveOn.value && isLocalFile.value && currentFileHandle.value) {
+    // Freeze the handle, markdown and history key together. The timeout must
+    // never consult live refs because navigation may replace them first.
+    const job = {
+      handle: currentFileHandle.value,
+      payload: {
+        markdown: exportableMarkdown(content.value),
+        snapshotContent: content.value,
+        snapshotKey: editIdentity,
+        revision: editRevision
+      }
+    }
+    autoSaveJob = job
+    autoSaveDirty = true
+    clearTimeout(autoSaveTimer)
+    autoSaveTimer = setTimeout(() => {
+      if (autoSaveJob !== job) return
+      autoSaveDirty = false
+      autoSaveJob = null
+      saveToFileHandle(job.handle, job.payload)
+    }, autoSaveDebounceMs())
+  }
 }, { flush: 'sync' })
 
 // Moving the caret to another row is a natural commit point: flush the
@@ -14355,7 +14360,7 @@ onBeforeUnmount(() => {
                       data-testid="autosave-interval-input"
                       class="input input-xs input-bordered w-16 text-right tabular-nums"
                       type="number"
-                      min="5"
+                      min="1"
                       max="3600"
                       step="1"
                       :value="autoSaveIntervalSeconds"
@@ -16041,7 +16046,7 @@ onBeforeUnmount(() => {
                   data-testid="floating-autosave-interval-input"
                   class="input input-xs input-bordered w-16 text-right tabular-nums"
                   type="number"
-                  min="5"
+                  min="1"
                   max="3600"
                   step="1"
                   :value="autoSaveIntervalSeconds"

--- a/src/lib/sourceEditing.js
+++ b/src/lib/sourceEditing.js
@@ -168,3 +168,189 @@ export const computeSelectionSurround = (value, start, end, char) => {
   const caret = from + char.length
   return { value: next, selectionStart: caret, selectionEnd: caret }
 }
+
+// ---- code-fence smart editing -------------------------------------------
+//
+// Inside a fenced code block the "everything stays literal" rule is reversed
+// for a small IDE-like subset: bracket/quote auto-pairing, Tab indentation and
+// Enter auto-indent. Outside fences nothing here fires, and mirror chars /
+// list / quote continuation still skip fences, so both halves stay disjoint.
+// Each function self-checks the fence and returns null otherwise.
+
+// Pairs that auto-close INSIDE a fence. The fence body is code, so quotes
+// delimit strings: the plain-text policy of "quotes stay literal" does not
+// apply there. `<` is deliberately NOT paired — as a less-than operator it is
+// typed far more often than as an HTML tag opener.
+const CODE_AUTO_PAIR = { '(': ')', '[': ']', '{': '}', '"': '"', "'": "'" }
+// All close characters of the pairs above. Typing one that already sits right
+// after the caret moves the caret past it (IDE overtype) instead of doubling
+// it — e.g. one `"` press closes `"abc|"` and `)` never piles up.
+const CODE_CLOSE_CHARS = new Set(Object.values(CODE_AUTO_PAIR))
+// Bracket groups that participate in Enter smart-indent (they map an unclosed
+// opener to the closer that may be pushed onto its own line).
+const BRACKET_CLOSE = { '(': ')', '[': ']', '{': '}' }
+
+// One full indent level inside code: four spaces (per user preference),
+// unless the line already indents with tabs.
+const indentUnitFor = (indent) => (indent || '').includes('\t') ? '\t' : '    '
+// Tab steps to the next 4-space tab stop instead of always inserting a full
+// level: a 3-space indent gets one more space, a 5-space one gets three.
+const tabStepFor = (indent) => {
+  if ((indent || '').includes('\t')) return '\t'
+  const gap = indent.length % 4
+  return ' '.repeat(gap === 0 ? 4 : 4 - gap)
+}
+
+// Typing a pair char inside a code fence: with a selection, wrap (or unwrap on
+// a second trigger); with no selection, auto-close with the caret in the
+// middle. An overtype rule applies to close/quote chars already at the caret.
+export const computeCodeAutoPair = (value, start, end, char) => {
+  const source = String(value || '')
+  const from = Math.min(source.length, toSafeInt(start, 0))
+  const to = Math.max(from, Math.min(source.length, toSafeInt(end, 0)))
+  if (typeof char !== 'string' || char.length !== 1) return null
+  const lineStart = source.lastIndexOf('\n', from - 1) + 1
+  if (!isInsideCodeFence(source, lineStart)) return null
+
+  if (from !== to) {
+    // Wrap the selection (or toggle it off when it is already wrapped by the
+    // same pair), mirroring the plain-text surround behaviour.
+    const close = CODE_AUTO_PAIR[char]
+    if (close === undefined) return null
+    const openBefore = from >= char.length && source.startsWith(char, from - char.length)
+    const closeAfter = source.startsWith(close, to)
+    if (openBefore && closeAfter) {
+      const next =
+        source.slice(0, from - char.length) +
+        source.slice(from, to) +
+        source.slice(to + close.length)
+      return {
+        value: next,
+        selectionStart: from - char.length,
+        selectionEnd: to - char.length
+      }
+    }
+    const next = source.slice(0, from) + char + source.slice(from, to) + close + source.slice(to)
+    return {
+      value: next,
+      selectionStart: from + char.length,
+      selectionEnd: to + char.length
+    }
+  }
+
+  // Overtype: the typed close char (or quote) is already the next character,
+  // so just step past it instead of inserting a duplicate.
+  if (CODE_CLOSE_CHARS.has(char) && source[from] === char) {
+    return { value: source, selectionStart: from + 1, selectionEnd: from + 1 }
+  }
+
+  const close = CODE_AUTO_PAIR[char]
+  if (close === undefined) return null
+  const next = source.slice(0, from) + char + close + source.slice(from)
+  const caret = from + char.length
+  return { value: next, selectionStart: caret, selectionEnd: caret }
+}
+
+// Stack of still-unclosed bracket openers in `text`, ignoring brackets inside
+// quoted strings (' " `, with backslash escapes) so a string literal such as
+// `"not (closed"` never counts as an open group.
+const codeOpenStack = (text) => {
+  const stack = []
+  let quote = null
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (quote) {
+      if (ch === '\\') i++
+      else if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch
+      continue
+    }
+    if (ch === '(' || ch === '[' || ch === '{') stack.push(ch)
+    else if (ch === ')' || ch === ']' || ch === '}') stack.pop()
+  }
+  return stack
+}
+
+// Enter inside a code fence: the next line keeps the current indentation; when
+// the caret sits inside an unclosed bracket group it indents one extra level.
+// Inside an EMPTY pair on the same line — `{|}` — the closer is pushed onto
+// its own line (indented like the opener) so the caret lands on the new body
+// line, mirroring an IDE's auto-indent:
+//   int main() {      int main() {
+//     |          →    <body, one level in>
+//   }                 }
+export const computeCodeEnterIndent = (value, caret) => {
+  const source = String(value || '')
+  const pos = Math.min(source.length, toSafeInt(caret, 0))
+  const { start, end } = lineBounds(source, pos)
+  if (!isInsideCodeFence(source, start)) return null
+  const line = source.slice(start, end)
+  const col = pos - start
+  const typed = line.slice(0, col)
+  const indent = /^(\s*)/.exec(line)[1]
+  // While the caret is inside the leading whitespace, carry exactly the
+  // whitespace before it; otherwise copy the line indent and, when the typed
+  // text ends inside an unclosed bracket group, add one more level.
+  const inLeadingWs = /^\s*$/.test(typed)
+  const base = inLeadingWs && typed.length < indent.length ? typed : indent
+  const stack = inLeadingWs ? [] : codeOpenStack(typed)
+
+  if (stack.length > 0) {
+    // Empty-pair split: when only whitespace (on this same line) separates the
+    // caret from the matching closer, move that closer onto its own line at the
+    // opener's indent and put the caret on a fresh body line one level in.
+    const rest = line.slice(col)
+    const gap = /^(\s*)(\S)/.exec(rest)
+    if (gap && gap[2] === BRACKET_CLOSE[stack[stack.length - 1]]) {
+      const bodyIndent = base + indentUnitFor(indent)
+      const closerRest = rest.slice(gap[1].length) // from the closer to EOL
+      const next = source.slice(0, pos) + '\n' + bodyIndent + '\n' + indent + closerRest + source.slice(end)
+      const caretAfter = pos + 1 + bodyIndent.length
+      return { value: next, selectionStart: caretAfter, selectionEnd: caretAfter }
+    }
+  }
+
+  const nextIndent = base + (stack.length > 0 ? indentUnitFor(indent) : '')
+  const next = source.slice(0, pos) + '\n' + nextIndent + source.slice(pos)
+  const caretAfter = pos + 1 + nextIndent.length
+  return { value: next, selectionStart: caretAfter, selectionEnd: caretAfter }
+}
+
+// Tab inside a code fence: with a collapsed caret, step to the next tab stop
+// (completing a partial indent rather than always adding a full level); with a
+// selection, indent every line the selection touches by one full level (empty
+// lines stay empty), keeping the selection extent. Fences outside untouched.
+export const computeCodeTab = (value, start, end) => {
+  const source = String(value || '')
+  const from = Math.min(source.length, toSafeInt(start, 0))
+  const to = Math.max(from, Math.min(source.length, toSafeInt(end, 0)))
+  const lineStart = source.lastIndexOf('\n', from - 1) + 1
+  if (!isInsideCodeFence(source, lineStart)) return null
+  const nl = source.indexOf('\n', lineStart)
+  const lineEnd = nl === -1 ? source.length : nl
+  const lineIndent = /^(\s*)/.exec(source.slice(lineStart, lineEnd))[1]
+
+  if (from === to) {
+    const step = tabStepFor(lineIndent)
+    const next = source.slice(0, from) + step + source.slice(from)
+    const caret = from + step.length
+    return { value: next, selectionStart: caret, selectionEnd: caret }
+  }
+
+  const unit = indentUnitFor(lineIndent)
+  const firstLineStart = source.lastIndexOf('\n', from - 1) + 1
+  const nlAfterEnd = source.indexOf('\n', to)
+  const lastLineEnd = nlAfterEnd === -1 ? source.length : nlAfterEnd
+  const body = source.slice(firstLineStart, lastLineEnd)
+  const lines = body.split('\n')
+  const indented = lines.map((l) => (l === '' ? l : unit + l)).join('\n')
+  const inserted = indented.length - body.length
+  // An empty first line gets no prefix, so the selection start shifts only
+  // when that line was actually indented.
+  const shiftStart = lines[0] === '' ? 0 : unit.length
+  const next = source.slice(0, firstLineStart) + indented + source.slice(lastLineEnd)
+  return { value: next, selectionStart: from + shiftStart, selectionEnd: to + inserted }
+}


### PR DESCRIPTION
### 概述

三组相互独立的功能改进，围绕分栏源码模式的编辑体验与文件保存体验。默认行为对现有用户**零破坏**（代码块编辑默认关、侧边栏仍默认左侧、自动保存仍默认开启 1 秒防抖——与现状一致），只是把之前写死的部分变成可配置并补齐缺失的反馈：

### 1. 代码块内 IDE 式智能编辑（「源码智能编辑」开关，默认关闭）

既有的「源码智能编辑」在代码块（```）内部一律跳过；本次为围栏内放开三类轻量 IDE 惯例，围栏外行为完全不变：

- **括号/引号自动配对**：输入 `(` `[` `{` 或引号 `"` `'` 自动补右符号、光标居中；右邻已是闭合符时 overtype 越过（如 `"abc|"` 打一个 `"` 即闭合字符串）；选中文字成对包裹、再按取消。`<` 刻意不配对（小于号远比标签常见），保持字面。
- **Tab 缩进**：跳到下一个 4 空格制表位（已有 3 空格再 Tab 只补 1 格；行内用 Tab 缩进的跟随 Tab）；多行选区逐行加一级、空行保持。
- **回车自动缩进**：回车保持当前缩进；光标在未闭合括号组内（字符串字面量不计）多缩一级；**空括号对**（`int main() {}` 光标在大括号中间）回车时闭合符移到独立行（对齐开括号缩进），光标落在中间新缩进行——与 IDE 一致。

实现为 `src/lib/sourceEditing.js` 新增三个纯字符串函数（无 DOM，自行判定围栏、围栏外返回 null），`App.vue` 的 `handleTextareaKeydown` 加法式接入；单测 +21（52/52），e2e 覆盖围栏内配对/overtype/下沉/开关关闭纯文本。

### 2. 分栏悬浮侧边栏方向可配（默认左侧，可镜像到右）

v1.1.54 把分栏模式的悬浮侧边栏（grip + outline/actions 面板）从右缘挪到左缘。本次加一个「浮动侧边栏靠右」设置项（导航「⋯」与面板内菜单均可切换，localStorage 持久化，默认关闭=保持左侧）：

- 右侧为完整镜像：悬停热区、把手与箭头方向、圆角/边框/阴影、滑入滑出动画全部对称；
- **切换交互**：开着面板切换方向时，面板先在**原侧**正确收回（退出动画不再错向），边缘再翻到另一侧；点切换即同时收起菜单与面板，无需再点空白。

### 3. 自动保存（默认开启，间隔可调，可一键关闭）+ 保存状态灯修正

- 保留并参数化原有的「编辑后防抖自动落盘」：默认开启、停顿 1 秒即保存（与现状一致，老用户无感）；菜单可**关闭**（回到纯手动 Ctrl+S）或把防抖间隔改为 1–3600 秒（默认 1）。保存走与 Ctrl+S 完全相同的底层 `saveToFileHandle()`，不派发按键事件、无感。
- 开启时 Save 按钮旁显示脉冲 **AUTO** 状态灯；菜单显示当前间隔并可直接输入秒数。
- **状态灯修正**：导航栏中央文件状态此前只在“从未保存的临时文件”时显示黄灯，保存一次后无论之后如何修改都常绿。现在它如实反映保存状态——文件与磁盘一致时绿灯显示文件名；之后**任何编辑**立即变黄并显示「有未保存更改」提示，直到手动保存或自动保存把内容写盘后回绿。

### 验证

- `npm run build` ✅
- source-editing 单测 52/52、tab-buffer 组 116/116、android-release 8/8 ✅
- Electron e2e：新增用例全部通过；修复前 CI 上因“自动保存默认关”而失配的 8 个既有用例（survive-autosave、8MiB/350k 大文档、reopen 竞态、Mermaid 落盘等）在“默认开启 1s”恢复后全部通过 ✅
- fork CI（tag v1.1.57）：validate / windows（sandbox-broker + source-editing + 全量 electron-ui e2e + 打包）/ linux；android 因 fork 无 keystore secrets fail-closed（预期）